### PR TITLE
fix: enhance skip logic in EnterpriseDiscoveryStage

### DIFF
--- a/internal/pipeline/stage_enterprise_discovery.go
+++ b/internal/pipeline/stage_enterprise_discovery.go
@@ -76,5 +76,8 @@ func (s *EnterpriseDiscoveryStage) Execute(ctx *ScanContext) error {
 }
 
 func (s *EnterpriseDiscoveryStage) Skip(ctx *ScanContext) bool {
-	return len(ctx.Params.Enterprises) > 0
+	// Skip auto-discovery when the user explicitly specified enterprises, organizations, or repositories.
+	return len(ctx.Params.Enterprises) > 0 ||
+		len(ctx.Params.Organizations) > 0 ||
+		len(ctx.Params.Repositories) > 0
 }


### PR DESCRIPTION
# Description

When running the `-o <org>` , it still attempts to the scan every enterprise you have access to as well as every organization underneath those enterprises. It seems like ideally the `-o <org>` is supposed to scan _just the organization specified_

```
./ghqr scan -o joshjohanning-org                                                                      
2026-03-10T11:42:37-05:00 INF Scan started stages=8
2026-03-10T11:42:37-05:00 INF Initializing scan...
2026-03-10T11:42:37-05:00 INF Authenticated to GitHub user=joshjohanning
2026-03-10T11:42:37-05:00 INF Discovering enterprises for authenticated user...
2026-03-10T11:42:38-05:00 INF Enterprises discovered count=9 enterprises=["enterprise1","enterprise2","enterprise3","enterprise4","enterprise5","enterprise6","enterprise7","enterprise8","enterprise9"]
2026-03-10T11:42:38-05:00 INF Starting enterprise scan count=9
2026-03-10T11:42:38-05:00 INF Scanning enterprise enterprise=enterprise1
2026-03-10T11:42:38-05:00 INF Starting enterprise scan enterprise=enterprise1
```

## Issue reference

n/a

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests (n/a)
* [x] Unit tests passing (n/a)
