### PR TITLE
Feature/emu detection

### DIFF
--- a/internal/pipeline/stage_organization_scan.go
+++ b/internal/pipeline/stage_organization_scan.go
@@ -49,7 +49,7 @@ func (s *OrganizationScanStage) Execute(ctx *ScanContext) error {
 func (s *OrganizationScanStage) scanOrganization(ctx *ScanContext, org string) error {
 	log.Info().Str("organization", org).Msg("Scanning organization")
 
-	scanner := scanners.NewOrganizationScanner(ctx.GitHubClient, org)
+	scanner := scanners.NewOrganizationScanner(ctx.GitHubClient, ctx.GitHubGraphQLClient, org)
 	data, err := scanner.ScanAll(ctx.Ctx)
 	if err != nil {
 		return fmt.Errorf("scan failed: %w", err)
@@ -59,6 +59,15 @@ func (s *OrganizationScanStage) scanOrganization(ctx *ScanContext, org string) e
 
 	// Record which enterprise owns this org (empty string for directly-specified orgs).
 	data.Enterprise = ctx.Ownership[fmt.Sprintf("organization:%s", org)]
+
+	// Propagate EMU status from the parent enterprise to the org settings.
+	if data.Enterprise != "" && data.Settings != nil {
+		if entData, ok := ctx.Results[fmt.Sprintf("enterprise:%s", data.Enterprise)]; ok {
+			if ent, ok := entData.(*scanners.EnterpriseData); ok && ent.Settings != nil {
+				data.Settings.Security.EMUEnabled = ent.Settings.EMUEnabled
+			}
+		}
+	}
 
 	log.Info().Str("organization", org).Msg("Organization scan completed successfully")
 	return nil

--- a/internal/recommendations/definitions/organization/security.yaml
+++ b/internal/recommendations/definitions/organization/security.yaml
@@ -9,6 +9,17 @@
   tags: [security, authentication]
   enabled: true
 
+- id: org-sec-001-emu
+  scope: organization
+  title: "EMU enabled: two-factor authentication is controlled by your identity provider"
+  category: security
+  severity: info
+  description: This organization belongs to an Enterprise Managed Users (EMU) enterprise. GitHub's organization-level 2FA setting does not apply because all authentication, including multi-factor authentication, is managed by the external identity provider (e.g. Microsoft Entra ID).
+  recommendation: Ensure MFA is enforced in your identity provider. For Microsoft Entra ID, configure a Conditional Access policy requiring MFA for all users.
+  learnMore: https://learn.microsoft.com/en-us/entra/identity/authentication/howto-mfa-getstarted
+  tags: [security, authentication, emu]
+  enabled: true
+
 - id: org-sec-002
   scope: organization
   title: Web commit signoff not required

--- a/internal/renderers/excel/organizations.go
+++ b/internal/renderers/excel/organizations.go
@@ -69,7 +69,11 @@ func buildOrganizationsTable(results map[string]interface{}) [][]string {
 		if s := orgData.Settings; s != nil {
 			defaultRepoPerm = s.Visibility.DefaultRepositoryPermission
 			membersCanCreatePublic = boolStr(s.Visibility.MembersCanCreatePublicRepositories)
-			twoFA = boolStr(s.Security.TwoFactorRequirementEnabled)
+			if s.Security.EMUEnabled {
+				twoFA = "IdP (EMU)"
+			} else {
+				twoFA = boolStr(s.Security.TwoFactorRequirementEnabled)
+			}
 			webCommitSignoff = boolStr(s.Security.WebCommitSignoffRequired)
 			advSecNewRepos = boolStr(s.Security.AdvancedSecurityForNewRepos)
 			dependabotAlertsNewRepos = boolStr(s.Security.DependabotAlertsForNewRepos)

--- a/internal/scanners/bestpractices/organization.go
+++ b/internal/scanners/bestpractices/organization.go
@@ -16,7 +16,11 @@ func (e *Evaluator) EvaluateOrganizationSecurity(settings *scanners.OrgSettings)
 	var findings []Issue
 
 	if !settings.Security.TwoFactorRequirementEnabled {
-		e.addFinding(&findings, "org-sec-001", "")
+		if settings.Security.EMUEnabled {
+			e.addFinding(&findings, "org-sec-001-emu", "")
+		} else {
+			e.addFinding(&findings, "org-sec-001", "")
+		}
 	}
 
 	if !settings.Security.WebCommitSignoffRequired {

--- a/internal/scanners/bestpractices/organization_test.go
+++ b/internal/scanners/bestpractices/organization_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package bestpractices_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/ghqr/internal/recommendations"
+	"github.com/microsoft/ghqr/internal/scanners"
+	"github.com/microsoft/ghqr/internal/scanners/bestpractices"
+)
+
+func newEvaluator(t *testing.T) *bestpractices.Evaluator {
+	t.Helper()
+	reg, err := recommendations.Load()
+	if err != nil {
+		t.Fatalf("recommendations.Load() error = %v", err)
+	}
+	return bestpractices.NewEvaluator(reg)
+}
+
+func findRuleID(result *bestpractices.EvaluationResult, ruleID string) *bestpractices.Issue {
+	for i := range result.Recommendations {
+		if result.Recommendations[i].RuleID == ruleID {
+			return &result.Recommendations[i]
+		}
+	}
+	return nil
+}
+
+func TestEvaluateOrganizationSecurity_NilSettings(t *testing.T) {
+	eval := newEvaluator(t)
+	result := eval.EvaluateOrganizationSecurity(nil)
+	if result == nil {
+		t.Fatal("expected non-nil result for nil settings")
+	}
+	if result.Message == "" {
+		t.Error("expected message for nil settings")
+	}
+}
+
+func TestEvaluateOrganizationSecurity_2FA_NotRequired_NoEMU(t *testing.T) {
+	eval := newEvaluator(t)
+	settings := &scanners.OrgSettings{
+		Security: scanners.OrgSecurity{
+			TwoFactorRequirementEnabled: false,
+			EMUEnabled:                  false,
+		},
+	}
+
+	result := eval.EvaluateOrganizationSecurity(settings)
+
+	issue := findRuleID(result, "org-sec-001")
+	if issue == nil {
+		t.Fatal("expected org-sec-001 finding when 2FA is not required and EMU is disabled")
+	}
+	if issue.Severity != "high" {
+		t.Errorf("org-sec-001 severity = %s, want high", issue.Severity)
+	}
+
+	emuIssue := findRuleID(result, "org-sec-001-emu")
+	if emuIssue != nil {
+		t.Error("unexpected org-sec-001-emu finding when EMU is disabled")
+	}
+}
+
+func TestEvaluateOrganizationSecurity_2FA_NotRequired_EMU(t *testing.T) {
+	eval := newEvaluator(t)
+	settings := &scanners.OrgSettings{
+		Security: scanners.OrgSecurity{
+			TwoFactorRequirementEnabled: false,
+			EMUEnabled:                  true,
+		},
+	}
+
+	result := eval.EvaluateOrganizationSecurity(settings)
+
+	emuIssue := findRuleID(result, "org-sec-001-emu")
+	if emuIssue == nil {
+		t.Fatal("expected org-sec-001-emu finding when EMU is enabled")
+	}
+	if emuIssue.Severity != "info" {
+		t.Errorf("org-sec-001-emu severity = %s, want info", emuIssue.Severity)
+	}
+
+	issue := findRuleID(result, "org-sec-001")
+	if issue != nil {
+		t.Error("unexpected org-sec-001 finding when EMU is enabled")
+	}
+}
+
+func TestEvaluateOrganizationSecurity_2FA_Required(t *testing.T) {
+	eval := newEvaluator(t)
+	settings := &scanners.OrgSettings{
+		Security: scanners.OrgSecurity{
+			TwoFactorRequirementEnabled: true,
+			WebCommitSignoffRequired:    true,
+		},
+	}
+
+	result := eval.EvaluateOrganizationSecurity(settings)
+
+	if findRuleID(result, "org-sec-001") != nil {
+		t.Error("unexpected org-sec-001 finding when 2FA is required")
+	}
+	if findRuleID(result, "org-sec-001-emu") != nil {
+		t.Error("unexpected org-sec-001-emu finding when 2FA is required")
+	}
+}

--- a/internal/scanners/enterprise.go
+++ b/internal/scanners/enterprise.go
@@ -65,6 +65,41 @@ func (e *EnterpriseScanner) getSettings(ctx context.Context) (*EnterpriseSetting
 	}, nil
 }
 
+// getEMUStatus checks whether the enterprise uses Enterprise Managed Users (EMU)
+// by querying the enterprise-level SAML identity provider via GraphQL.
+// When a SAML IdP is configured at the enterprise level, the enterprise is EMU-enabled
+// and authentication (including 2FA) is managed by the external identity provider.
+// Returns false (no error) if the query fails due to insufficient permissions.
+func (e *EnterpriseScanner) getEMUStatus(ctx context.Context) (bool, error) {
+	log.Debug().Str("enterprise", e.enterprise).Msg("Checking enterprise EMU status via GraphQL")
+
+	var query struct {
+		Enterprise struct {
+			OwnerInfo struct {
+				SamlIdentityProvider *struct {
+					ID githubv4.ID
+				}
+			}
+		} `graphql:"enterprise(slug: $slug)"`
+	}
+
+	variables := map[string]interface{}{
+		"slug": githubv4.String(e.enterprise),
+	}
+
+	if err := e.graphqlClient.Query(ctx, &query, variables); err != nil {
+		log.Debug().Err(err).Str("enterprise", e.enterprise).
+			Msg("Failed to query enterprise EMU status (may require admin:enterprise scope)")
+		return false, nil
+	}
+
+	emuEnabled := query.Enterprise.OwnerInfo.SamlIdentityProvider != nil
+	if emuEnabled {
+		log.Info().Str("enterprise", e.enterprise).Msg("Enterprise Managed Users (EMU) detected")
+	}
+	return emuEnabled, nil
+}
+
 // getOrganizations retrieves all organizations in the enterprise via GraphQL, paginating
 // through all pages so enterprises with >100 orgs are fully discovered.
 func (e *EnterpriseScanner) getOrganizations(ctx context.Context) ([]*github.Organization, error) {
@@ -312,6 +347,13 @@ func (e *EnterpriseScanner) ScanAll(ctx context.Context) (*EnterpriseData, error
 		return nil, err
 	}
 	data.Settings = settings
+
+	emuEnabled, err := e.getEMUStatus(ctx)
+	if err != nil {
+		log.Warn().Err(err).Str("enterprise", e.enterprise).Msg("Failed to check EMU status")
+	} else if data.Settings != nil {
+		data.Settings.EMUEnabled = emuEnabled
+	}
 
 	orgs, err := e.getOrganizations(ctx)
 	if err != nil {

--- a/internal/scanners/enterprise_types.go
+++ b/internal/scanners/enterprise_types.go
@@ -33,6 +33,9 @@ type EnterpriseSettings struct {
 	URL         string `json:"url,omitempty"`
 	WebsiteURL  string `json:"website_url,omitempty"`
 	CreatedAt   string `json:"created_at,omitempty"`
+	// EMUEnabled is true when the enterprise uses Enterprise Managed Users.
+	// When EMU is active, authentication (including 2FA) is managed by the IdP.
+	EMUEnabled bool `json:"emu_enabled"`
 }
 
 // EnterpriseAuditLogData holds a summary of recent audit log events.

--- a/internal/scanners/organization.go
+++ b/internal/scanners/organization.go
@@ -11,19 +11,22 @@ import (
 
 	"github.com/google/go-github/v83/github"
 	"github.com/rs/zerolog/log"
+	"github.com/shurcooL/githubv4"
 )
 
 // OrganizationScanner handles scanning organization-level data
 type OrganizationScanner struct {
-	client *github.Client
-	org    string
+	client        *github.Client
+	graphqlClient *githubv4.Client
+	org           string
 }
 
 // NewOrganizationScanner creates a new organization scanner
-func NewOrganizationScanner(client *github.Client, org string) *OrganizationScanner {
+func NewOrganizationScanner(client *github.Client, graphqlClient *githubv4.Client, org string) *OrganizationScanner {
 	return &OrganizationScanner{
-		client: client,
-		org:    org,
+		client:        client,
+		graphqlClient: graphqlClient,
+		org:           org,
 	}
 }
 
@@ -206,6 +209,64 @@ func (o *OrganizationScanner) scanSecurityManagers(ctx context.Context) (*OrgSec
 	return &OrgSecurityManagers{HasSecurityManager: len(teams) > 0}, nil
 }
 
+// checkEMUStatus checks whether the organization belongs to an EMU enterprise.
+// It first attempts a GraphQL query against the enterprise's SAML identity provider
+// (requires admin:enterprise scope). If that fails or returns no data, it falls
+// back to probing the REST external-groups endpoint which is only available for
+// EMU organizations and requires only read:org scope.
+func (o *OrganizationScanner) checkEMUStatus(ctx context.Context) (bool, error) {
+	// Attempt 1: GraphQL enterprise SAML IdP (works if token has enterprise admin scope).
+	if o.graphqlClient != nil {
+		log.Debug().Str("organization", o.org).Msg("Checking EMU status via GraphQL")
+
+		var query struct {
+			Organization struct {
+				Enterprise *struct {
+					OwnerInfo struct {
+						SamlIdentityProvider *struct {
+							ID githubv4.ID
+						}
+					}
+				}
+			} `graphql:"organization(login: $login)"`
+		}
+
+		variables := map[string]interface{}{
+			"login": githubv4.String(o.org),
+		}
+
+		if err := o.graphqlClient.Query(ctx, &query, variables); err == nil {
+			if query.Organization.Enterprise != nil &&
+				query.Organization.Enterprise.OwnerInfo.SamlIdentityProvider != nil {
+				log.Info().Str("organization", o.org).Msg("Enterprise Managed Users (EMU) detected via GraphQL")
+				return true, nil
+			}
+		} else {
+			log.Debug().Err(err).Str("organization", o.org).
+				Msg("GraphQL EMU check failed (may require admin:enterprise scope), trying REST fallback")
+		}
+	}
+
+	// Attempt 2: REST external-groups endpoint (only exists for EMU orgs, needs read:org).
+	log.Debug().Str("organization", o.org).Msg("Checking EMU status via REST external-groups")
+	u := fmt.Sprintf("orgs/%s/external-groups", o.org)
+	req, err := o.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return false, nil
+	}
+	resp, err := o.client.Do(ctx, req, nil)
+	if err == nil && resp.StatusCode == http.StatusOK {
+		log.Info().Str("organization", o.org).Msg("Enterprise Managed Users (EMU) detected via external-groups")
+		return true, nil
+	}
+	if resp != nil {
+		log.Debug().Int("status", resp.StatusCode).Str("organization", o.org).
+			Msg("External-groups not available (org is not EMU)")
+	}
+
+	return false, nil
+}
+
 // ScanAll retrieves organization settings and Copilot info.
 func (o *OrganizationScanner) ScanAll(ctx context.Context) (*OrganizationData, error) {
 	log.Info().Str("organization", o.org).Msg("Starting organization scan")
@@ -217,6 +278,13 @@ func (o *OrganizationScanner) ScanAll(ctx context.Context) (*OrganizationData, e
 		return nil, fmt.Errorf("failed to get organization: %w", err)
 	}
 	data.Settings = o.extractSettings(org)
+
+	emuEnabled, err := o.checkEMUStatus(ctx)
+	if err != nil {
+		log.Warn().Err(err).Str("organization", o.org).Msg("Failed to check EMU status")
+	} else {
+		data.Settings.Security.EMUEnabled = emuEnabled
+	}
 
 	copilot, err := o.scanCopilot(ctx)
 	if err != nil {

--- a/internal/scanners/organization_types.go
+++ b/internal/scanners/organization_types.go
@@ -29,6 +29,9 @@ type OrgVisibility struct {
 type OrgSecurity struct {
 	TwoFactorRequirementEnabled bool `json:"two_factor_requirement_enabled"`
 	WebCommitSignoffRequired    bool `json:"web_commit_signoff_required"`
+	// EMUEnabled is true when the parent enterprise uses Enterprise Managed Users.
+	// When EMU is active, 2FA is managed by the identity provider, not GitHub.
+	EMUEnabled bool `json:"emu_enabled"`
 
 	// Org-wide defaults applied to new repositories
 	AdvancedSecurityForNewRepos             bool `json:"advanced_security_enabled_for_new_repos"`


### PR DESCRIPTION
## Description
Adds Enterprise Managed Users (EMU) detection to the organization security scan. Previously, organizations belonging to an EMU enterprise were flagged with a High severity finding for not having GitHub-level 2FA enabled. This is a false positive — EMU organizations delegate all authentication, including MFA, to the external identity provider (e.g. Microsoft Entra ID).

## Changes:

- EMU detection at the enterprise level — queries the enterprise SAML identity provider via GraphQL (ownerInfo.samlIdentityProvider) during enterprise scans
- EMU detection at the organization level — uses a two-step approach: GraphQL query against the org's parent enterprise (if [admin:enterprise](vscode-file://vscode-app/c:/Users/ajenns/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) scope is available), with a REST fallback probing GET /orgs/{org}/external-groups (requires only [read:org](vscode-file://vscode-app/c:/Users/ajenns/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) scope). This ensures EMU is detected regardless of whether the scan is run with [--enterprise](vscode-file://vscode-app/c:/Users/ajenns/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) or [--org](vscode-file://vscode-app/c:/Users/ajenns/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Updated 2FA evaluation — when EMU is detected, the evaluator emits [org-sec-001-emu](vscode-file://vscode-app/c:/Users/ajenns/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (Info severity) instead of [org-sec-001](vscode-file://vscode-app/c:/Users/ajenns/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (High severity), with guidance to enforce MFA in the identity provider
- Updated report rendering — Excel output shows "IdP (EMU)" in the 2FA column for EMU organizations; Markdown findings display the updated recommendation with a link to Entra ID MFA configuration
- Added unit tests — 4 test cases covering nil settings, 2FA not required without EMU, 2FA not required with EMU, and 2FA already enabled

## Checklist


- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing