### PR TITLE
feat: add --hostname flag for GitHub Enterprise Data Residency (GHE.com) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,23 @@ ghqr scan -e my-enterprise
 | `read:user` | Read user information |
 | `copilot` | Read Copilot seat and policy information |
 
+### GitHub Enterprise Cloud with Data Residency (GHE.com)
+
+If your organization uses [GitHub Enterprise Cloud with data residency](https://docs.github.com/en/enterprise-cloud@latest/admin/data-residency/about-github-enterprise-cloud-with-data-residency), your API endpoints are on a custom `ghe.com` subdomain instead of `github.com`.
+
+Specify your hostname using either:
+
+- The `--hostname` / `-H` flag: `ghqr scan -o my-org -H mycompany.ghe.com`
+- The `GH_HOST` environment variable: `export GH_HOST=mycompany.ghe.com`
+
 ### Running Scans
 
 ```bash
 # Scan a single organization
 ghqr scan
 ```
+
+For GitHub Enterprise Cloud with Data Residency, see [Data Residency](#github-enterprise-cloud-with-data-residency-ghecom).
 
 Run `ghqr -h` for all available commands and options.
 
@@ -163,6 +174,7 @@ If you receive `401 Unauthorized` or `403 Forbidden` errors:
 1. Verify your `GITHUB_TOKEN` is set and valid
 2. Check that your token has the required scopes (see [Required Token Scopes](#required-token-scopes))
 3. For enterprise resources, ensure your token has `read:enterprise` scope and that SSO is authorized for the enterprise
+4. If using GitHub Enterprise Cloud with Data Residency (GHE.com), ensure you pass `--hostname` or set `GH_HOST` (see [Data Residency](#github-enterprise-cloud-with-data-residency-ghecom))
 
 ### Rate Limiting
 

--- a/cmd/ghqr/commands/scan.go
+++ b/cmd/ghqr/commands/scan.go
@@ -4,6 +4,8 @@
 package commands
 
 import (
+	"os"
+
 	"github.com/microsoft/ghqr/internal/models"
 	"github.com/microsoft/ghqr/internal/pipeline"
 
@@ -16,6 +18,7 @@ func init() {
 	scanCmd.PersistentFlags().StringArrayP("organization", "o", []string{}, "GitHub Organization(s) to scan (can be specified multiple times)")
 	scanCmd.PersistentFlags().StringArrayP("repository", "r", []string{}, "GitHub Repository (owner/repo)")
 	scanCmd.PersistentFlags().StringP("output-name", "n", "", "Output file name without extension")
+	scanCmd.PersistentFlags().StringP("hostname", "H", "", "GitHub hostname (e.g. mycompany.ghe.com for Data Residency). Defaults to github.com. Also reads GH_HOST env var")
 	scanCmd.PersistentFlags().Bool("xlsx", true, "Create Excel (.xlsx) report")
 	scanCmd.PersistentFlags().Bool("markdown", true, "Create Markdown (.md) executive report")
 
@@ -52,11 +55,17 @@ Examples:
 }
 
 func scan(cmd *cobra.Command) {
+	hostname := getString(cmd, "hostname")
+	if hostname == "" {
+		hostname = os.Getenv("GH_HOST")
+	}
+
 	params := models.ScanParams{
 		Enterprises:   getStringArray(cmd, "enterprise"),
 		Organizations: getStringArray(cmd, "organization"),
 		Repositories:  getStringArray(cmd, "repository"),
 		OutputName:    getString(cmd, "output-name"),
+		Hostname:      hostname,
 		Debug:         getBool(cmd, "debug"),
 		Xlsx:          getBool(cmd, "xlsx"),
 		Markdown:      getBool(cmd, "markdown"),

--- a/internal/config/github.go
+++ b/internal/config/github.go
@@ -19,7 +19,9 @@ import (
 // GitHubClients creates and returns a configured HTTP client and GraphQL client that share
 // the same authentication and rate-limit retry transport.
 // Use the returned *http.Client for raw HTTP requests (e.g. batch GraphQL queries).
-func GitHubClients(ctx context.Context) (*http.Client, *githubv4.Client) {
+// hostname is the GitHub hostname (e.g. "mycompany.ghe.com" for Data Residency).
+// Pass "" or "github.com" for standard GitHub.com.
+func GitHubClients(ctx context.Context, hostname string) (*http.Client, *githubv4.Client) {
 	token := os.Getenv("GITHUB_TOKEN")
 	if token == "" {
 		token = os.Getenv("GH_TOKEN")
@@ -36,7 +38,34 @@ func GitHubClients(ctx context.Context) (*http.Client, *githubv4.Client) {
 	httpClient := &http.Client{
 		Transport: &rateLimitTransport{wrapped: oauthTransport},
 	}
+
+	if IsCustomHost(hostname) {
+		graphqlURL := "https://api." + hostname + "/graphql"
+		return httpClient, githubv4.NewEnterpriseClient(graphqlURL, httpClient)
+	}
 	return httpClient, githubv4.NewClient(httpClient)
+}
+
+// IsCustomHost returns true when the hostname refers to a non-default GitHub instance
+// (e.g. a GHE.com Data Residency subdomain).
+func IsCustomHost(hostname string) bool {
+	return hostname != "" && hostname != "github.com"
+}
+
+// GraphQLEndpoint returns the GraphQL API endpoint for the given hostname.
+func GraphQLEndpoint(hostname string) string {
+	if IsCustomHost(hostname) {
+		return "https://api." + hostname + "/graphql"
+	}
+	return "https://api.github.com/graphql"
+}
+
+// RESTBaseURL returns the REST API base URL for the given hostname.
+func RESTBaseURL(hostname string) string {
+	if IsCustomHost(hostname) {
+		return "https://api." + hostname + "/"
+	}
+	return "https://api.github.com/"
 }
 
 // rateLimitTransport retries requests that hit GitHub rate limits.

--- a/internal/config/github_test.go
+++ b/internal/config/github_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package config
+
+import "testing"
+
+func TestIsCustomHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		want     bool
+	}{
+		{name: "empty string", hostname: "", want: false},
+		{name: "github.com", hostname: "github.com", want: false},
+		{name: "ghe.com subdomain", hostname: "mycompany.ghe.com", want: true},
+		{name: "ghes instance", hostname: "github.example.com", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsCustomHost(tt.hostname)
+			if got != tt.want {
+				t.Errorf("IsCustomHost(%q) = %v, want %v", tt.hostname, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGraphQLEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		want     string
+	}{
+		{name: "empty defaults to github.com", hostname: "", want: "https://api.github.com/graphql"},
+		{name: "github.com", hostname: "github.com", want: "https://api.github.com/graphql"},
+		{name: "ghe.com subdomain", hostname: "mycompany.ghe.com", want: "https://api.mycompany.ghe.com/graphql"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GraphQLEndpoint(tt.hostname)
+			if got != tt.want {
+				t.Errorf("GraphQLEndpoint(%q) = %q, want %q", tt.hostname, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRESTBaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		want     string
+	}{
+		{name: "empty defaults to github.com", hostname: "", want: "https://api.github.com/"},
+		{name: "github.com", hostname: "github.com", want: "https://api.github.com/"},
+		{name: "ghe.com subdomain", hostname: "mycompany.ghe.com", want: "https://api.mycompany.ghe.com/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RESTBaseURL(tt.hostname)
+			if got != tt.want {
+				t.Errorf("RESTBaseURL(%q) = %q, want %q", tt.hostname, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/models/scan_params.go
+++ b/internal/models/scan_params.go
@@ -8,6 +8,7 @@ type ScanParams struct {
 	Organizations []string
 	Repositories  []string
 	OutputName    string
+	Hostname      string
 	Debug         bool
 	Xlsx          bool
 	Markdown      bool

--- a/internal/pipeline/stage_initialization.go
+++ b/internal/pipeline/stage_initialization.go
@@ -6,6 +6,7 @@ package pipeline
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/google/go-github/v83/github"
@@ -33,14 +34,22 @@ func (s *InitializationStage) Execute(ctx *ScanContext) error {
 		return fmt.Errorf("GitHub token not found: set GH_TOKEN or GITHUB_TOKEN environment variable")
 	}
 
+	hostname := ctx.Params.Hostname
+
 	// Create REST API client
 	httpClient := &http.Client{
 		Transport: &tokenTransport{token: token},
 	}
 	ctx.GitHubClient = github.NewClient(httpClient)
 
+	if config.IsCustomHost(hostname) {
+		baseURL, _ := url.Parse(config.RESTBaseURL(hostname))
+		ctx.GitHubClient.BaseURL = baseURL
+		log.Info().Str("hostname", hostname).Msg("Using custom GitHub hostname")
+	}
+
 	// Create GraphQL client (and keep the underlying HTTP client for batch queries).
-	ctx.GitHubRawHTTPClient, ctx.GitHubGraphQLClient = config.GitHubClients(ctx.Ctx)
+	ctx.GitHubRawHTTPClient, ctx.GitHubGraphQLClient = config.GitHubClients(ctx.Ctx, hostname)
 
 	user, _, err := ctx.GitHubClient.Users.Get(ctx.Ctx, "")
 	if err != nil {

--- a/internal/pipeline/stage_org_repository_scan.go
+++ b/internal/pipeline/stage_org_repository_scan.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/microsoft/ghqr/internal/config"
 	"github.com/microsoft/ghqr/internal/scanners"
 	"github.com/rs/zerolog/log"
 )
@@ -27,7 +28,8 @@ func NewOrgRepositoryScanStage() *OrgRepositoryScanStage {
 }
 
 func (s *OrgRepositoryScanStage) Execute(ctx *ScanContext) error {
-	graphqlClient := scanners.NewGraphQLClient(ctx.GitHubGraphQLClient, ctx.GitHubRawHTTPClient)
+	graphqlEndpoint := config.GraphQLEndpoint(ctx.Params.Hostname)
+	graphqlClient := scanners.NewGraphQLClient(ctx.GitHubGraphQLClient, ctx.GitHubRawHTTPClient, graphqlEndpoint)
 
 	workers := 2
 
@@ -114,6 +116,8 @@ func (s *OrgRepositoryScanStage) enrichWithRulesets(ctx *ScanContext, org string
 		return
 	}
 
+	graphqlEndpoint := config.GraphQLEndpoint(ctx.Params.Hostname)
+
 	prefix := fmt.Sprintf("repository:%s/", org)
 	var needsEnrichment []string
 	for key, val := range ctx.Results {
@@ -154,7 +158,7 @@ func (s *OrgRepositoryScanStage) enrichWithRulesets(ctx *ScanContext, org string
 			branch = "main"
 		}
 
-		detail := scanners.FetchRulesetProtection(ctx.Ctx, ctx.GitHubRawHTTPClient, org, repo.Name, branch)
+		detail := scanners.FetchRulesetProtection(ctx.Ctx, ctx.GitHubRawHTTPClient, graphqlEndpoint, org, repo.Name, branch)
 		if detail != nil && detail.Protected {
 			repo.RulesetProtection = detail
 			log.Debug().

--- a/internal/scanners/batch.go
+++ b/internal/scanners/batch.go
@@ -16,7 +16,7 @@ import (
 	"github.com/shurcooL/githubv4"
 )
 
-const githubGraphQLEndpoint = "https://api.github.com/graphql"
+const defaultGraphQLEndpoint = "https://api.github.com/graphql"
 
 // BatchSize is the number of repositories fetched per batch GraphQL request.
 // Kept small (5) to stay within GitHub's query-complexity resource limits;
@@ -210,7 +210,12 @@ func (c *GraphQLClient) FetchRepositoriesBatch(ctx context.Context, owner string
 		return nil, fmt.Errorf("failed to marshal batch query: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, githubGraphQLEndpoint, bytes.NewReader(body))
+	endpoint := c.graphqlEndpoint
+	if endpoint == "" {
+		endpoint = defaultGraphQLEndpoint
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create batch request: %w", err)
 	}

--- a/internal/scanners/graphql_client.go
+++ b/internal/scanners/graphql_client.go
@@ -11,17 +11,20 @@ import (
 // httpClient is the underlying HTTP client used by the githubv4 client;
 // it is reused for batch queries that require raw HTTP POST requests.
 type GraphQLClient struct {
-	client     *githubv4.Client
-	httpClient *http.Client
+	client          *githubv4.Client
+	httpClient      *http.Client
+	graphqlEndpoint string
 }
 
 // NewGraphQLClient creates a new GraphQL client wrapper.
 // httpClient should be the same HTTP client used to create the githubv4 client
 // so that authentication and rate-limit retry logic are shared.
-func NewGraphQLClient(client *githubv4.Client, httpClient *http.Client) *GraphQLClient {
+// graphqlEndpoint is the GraphQL API URL (e.g. "https://api.github.com/graphql").
+func NewGraphQLClient(client *githubv4.Client, httpClient *http.Client, graphqlEndpoint string) *GraphQLClient {
 	return &GraphQLClient{
-		client:     client,
-		httpClient: httpClient,
+		client:          client,
+		httpClient:      httpClient,
+		graphqlEndpoint: graphqlEndpoint,
 	}
 }
 

--- a/internal/scanners/ruleset.go
+++ b/internal/scanners/ruleset.go
@@ -88,9 +88,13 @@ type gqlRulesetParameters struct {
 // FetchRulesetProtection queries the GraphQL API for active repository rulesets
 // and converts them into a RulesetProtectionDetail. It uses the raw HTTP client
 // (same auth as batch queries) so it works reliably with all token types.
-func FetchRulesetProtection(ctx context.Context, httpClient *http.Client, owner, repo, branch string) *RulesetProtectionDetail {
+func FetchRulesetProtection(ctx context.Context, httpClient *http.Client, graphqlEndpoint, owner, repo, branch string) *RulesetProtectionDetail {
 	if httpClient == nil || branch == "" {
 		return nil
+	}
+
+	if graphqlEndpoint == "" {
+		graphqlEndpoint = defaultGraphQLEndpoint
 	}
 
 	payload := struct {
@@ -110,7 +114,7 @@ func FetchRulesetProtection(ctx context.Context, httpClient *http.Client, owner,
 		return nil
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, githubGraphQLEndpoint, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, graphqlEndpoint, bytes.NewReader(body))
 	if err != nil {
 		log.Debug().Err(err).Msg("Failed to create rulesets request")
 		return nil


### PR DESCRIPTION
# Description

Add support for GitHub Enterprise Cloud with data residency (GHE.com), where API endpoints use a custom `ghe.com` subdomain instead of `github.com`. Without this, users on GHE.com get `401 Bad credentials` because all API calls are hardcoded to `api.github.com`.

Adds a `--hostname` / `-H` flag (and `GH_HOST` env var fallback) to configure the REST and GraphQL API base URLs for custom hosts.

Tested manually against a GHE.com Data Residency instance (Japan region) — authentication, org scan, and batch repository queries all work correctly.

## Issue reference

Closes #51

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing