### PR TITLE
fix: typo unparseable should be unparsable

### DIFF
--- a/internal/scanners/enterprise.go
+++ b/internal/scanners/enterprise.go
@@ -224,7 +224,7 @@ func (e *EnterpriseScanner) getAuditLog(ctx context.Context) (*EnterpriseAuditLo
 	for _, entryBytes := range raw {
 		var entry rawAuditEntry
 		if err := json.Unmarshal(entryBytes, &entry); err != nil {
-			log.Debug().Err(err).Msg("Skipping unparseable audit log entry")
+			log.Debug().Err(err).Msg("Skipping unparsable audit log entry")
 			continue
 		}
 		if suspiciousActions[entry.Action] {


### PR DESCRIPTION
## Description
Typo in log message: `unparseable` should be `unparsable`

## Fix
Changed `unparseable` to `unparsable` in internal/scanners/enterprise.go:227

## Changes
- Fixed typo in error message: unparseable -> unparsable

Signed-off-by: luojiyin <luojiyin@hotmail.com>

---

**Related Issue:** #67