### PR TITLE
fix: support macOS in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,15 +6,22 @@ then
     exit
 fi
 
+os=$(uname -s)
+if [ "$os" == "Darwin" ]; then
+    os="darwin"
+else
+    os="linux"
+fi
+
 arch=$(uname -m)
-if [ "$arch" == "aarch64" ]; then
+if [ "$arch" == "aarch64" ] || [ "$arch" == "arm64" ]; then
     arch="arm64"
 else
     arch="amd64"
 fi
 
 latest_ghqr=$(curl -sL https://api.github.com/repos/microsoft/ghqr/releases/latest | jq -r ".tag_name" | cut -c1-)
-wget https://github.com/microsoft/ghqr/releases/download/$latest_ghqr/ghqr-linux-$arch.zip -O ghqr.zip
+wget https://github.com/microsoft/ghqr/releases/download/$latest_ghqr/ghqr-$os-$arch.zip -O ghqr.zip
 unzip -uj -qq ghqr.zip
 rm ghqr.zip
 chmod +x ghqr


### PR DESCRIPTION
# Description

This PR fixes the install script: it downloads the correct release asset depending on the host operating system and architecture.

Previously, the script always downloaded the Linux binary:

```bash
ghqr-linux-$arch.zip
```

On macOS, this resulted in downloading a Linux executable and then failing with:

```
./ghqr: cannot execute binary file
```

This PR keeps the existing script structure while adding:
- OS detection using uname -s
- support for macOS release assets using darwin
- support for arm64 on macOS


The script now downloads assets such as:
```
ghqr-darwin-arm64.zip
ghqr-linux-amd64.zip
```


## Issue reference

No issue was opened before this PR.

## Checklist

Tested successfully on macOS arm64:
```
uname -s
# Darwin

bash scripts/install.sh
# Downloads ghqr-darwin-arm64.zip
# ghqr version v.0.2.0
```

also tested successfully on Linux amd64:
```
uname -s
# Linux

uname -m
# x86_64

bash scripts/install.sh
# Downloads ghqr-linux-amd64.zip
# ghqr version v.0.2.0
```
