### PR TITLE
feat: add support for replaying enrichment from existing scan JSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,16 @@ ghqr scan
 
 For GitHub Enterprise Cloud with Data Residency, see [Data Residency](#github-enterprise-cloud-with-data-residency-ghecom).
 
+### Replaying Enrichment from a Previous Scan
+
+To iterate on evaluation rules or re-render reports without re-querying GitHub, replay an existing scan JSON file:
+
+```bash
+ghqr scan --from-json ghqr_20260417_143426.json
+```
+
+The scan stages are skipped — no GitHub API calls or token are required — and a fresh `<input>_replay_<timestamp>.json` (plus xlsx/markdown when enabled) is produced. Note: the JSON renderer compacts `collaborators` and `deploy_keys` arrays into summaries, so per-collaborator and per-deploy-key rules cannot be re-evaluated from a replayed file.
+
 Run `ghqr -h` for all available commands and options.
 
 ### MCP Server (Model Context Protocol)

--- a/cmd/ghqr/commands/scan.go
+++ b/cmd/ghqr/commands/scan.go
@@ -21,6 +21,7 @@ func init() {
 	scanCmd.PersistentFlags().StringP("hostname", "H", "", "GitHub hostname (e.g. mycompany.ghe.com for Data Residency). Defaults to github.com. Also reads GH_HOST env var")
 	scanCmd.PersistentFlags().Bool("xlsx", true, "Create Excel (.xlsx) report")
 	scanCmd.PersistentFlags().Bool("markdown", true, "Create Markdown (.md) executive report")
+	scanCmd.PersistentFlags().String("from-json", "", "Replay enrichment from an existing scan JSON file (skips all GitHub API calls)")
 
 	rootCmd.AddCommand(scanCmd)
 }
@@ -53,7 +54,10 @@ Examples:
   ghqr scan -e my-enterprise -n my-audit-2024
 
   # Scan and generate JSON output
-  ghqr scan -e my-enterprise --json`,
+  ghqr scan -e my-enterprise --json
+
+  # Replay enrichment against an existing scan JSON (no GitHub API calls)
+  ghqr scan --from-json ghqr_20260417_143426.json`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		scan(cmd)
@@ -66,15 +70,30 @@ func scan(cmd *cobra.Command) {
 		hostname = os.Getenv("GH_HOST")
 	}
 
+	fromJSON := getString(cmd, "from-json")
+	enterprises := getStringArray(cmd, "enterprise")
+	organizations := getStringArray(cmd, "organization")
+	repositories := getStringArray(cmd, "repository")
+
+	if fromJSON != "" && (len(enterprises) > 0 || len(organizations) > 0 || len(repositories) > 0) {
+		log.Fatal().Msg("--from-json cannot be combined with -e/--enterprise, -o/--organization, or -r/--repository")
+	}
+	if fromJSON != "" {
+		if _, err := os.Stat(fromJSON); err != nil {
+			log.Fatal().Err(err).Str("path", fromJSON).Msg("--from-json file is not accessible")
+		}
+	}
+
 	params := models.ScanParams{
-		Enterprises:   getStringArray(cmd, "enterprise"),
-		Organizations: getStringArray(cmd, "organization"),
-		Repositories:  getStringArray(cmd, "repository"),
+		Enterprises:   enterprises,
+		Organizations: organizations,
+		Repositories:  repositories,
 		OutputName:    getString(cmd, "output-name"),
 		Hostname:      hostname,
 		Debug:         getBool(cmd, "debug"),
 		Xlsx:          getBool(cmd, "xlsx"),
 		Markdown:      getBool(cmd, "markdown"),
+		FromJSON:      fromJSON,
 	}
 
 	scanner := pipeline.Scanner{}

--- a/internal/models/scan_params.go
+++ b/internal/models/scan_params.go
@@ -12,4 +12,8 @@ type ScanParams struct {
 	Debug         bool
 	Xlsx          bool
 	Markdown      bool
+	// FromJSON, when set, points to an existing scan JSON file. The pipeline
+	// loads results from this file and skips all GitHub API scan stages,
+	// re-running only enrichment (evaluation) and report rendering.
+	FromJSON string
 }

--- a/internal/pipeline/builder.go
+++ b/internal/pipeline/builder.go
@@ -6,6 +6,8 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/microsoft/ghqr/internal/models"
@@ -31,6 +33,12 @@ func (b *ScanPipelineBuilder) addStage(stage Stage) *ScanPipelineBuilder {
 // WithInitialization adds the initialization stage.
 func (b *ScanPipelineBuilder) WithInitialization() *ScanPipelineBuilder {
 	return b.addStage(NewInitializationStage())
+}
+
+// WithLoadFromJSON adds the load-from-json replay stage. The stage self-skips
+// unless ScanParams.FromJSON is set.
+func (b *ScanPipelineBuilder) WithLoadFromJSON() *ScanPipelineBuilder {
+	return b.addStage(NewLoadFromJSONStage())
 }
 
 // WithEnterpriseScan adds the enterprise scanning stage.
@@ -82,6 +90,7 @@ func (b *ScanPipelineBuilder) Build() *Pipeline {
 func (b *ScanPipelineBuilder) BuildDefault() *Pipeline {
 	return b.
 		WithInitialization().
+		WithLoadFromJSON().
 		WithEnterpriseDiscovery().
 		WithEnterpriseScan().
 		WithOrganizationDiscovery().
@@ -100,7 +109,13 @@ func NewScanContext(params *models.ScanParams) *ScanContext {
 
 	outputName := params.OutputName
 	if outputName == "" {
-		outputName = fmt.Sprintf("ghqr_%s", startTime.Format("20060102_150405"))
+		if params.FromJSON != "" {
+			base := filepath.Base(params.FromJSON)
+			base = strings.TrimSuffix(base, filepath.Ext(base))
+			outputName = fmt.Sprintf("%s_replay_%s", base, startTime.Format("20060102_150405"))
+		} else {
+			outputName = fmt.Sprintf("ghqr_%s", startTime.Format("20060102_150405"))
+		}
 	}
 
 	return &ScanContext{

--- a/internal/pipeline/stage_enterprise_discovery.go
+++ b/internal/pipeline/stage_enterprise_discovery.go
@@ -76,8 +76,10 @@ func (s *EnterpriseDiscoveryStage) Execute(ctx *ScanContext) error {
 }
 
 func (s *EnterpriseDiscoveryStage) Skip(ctx *ScanContext) bool {
-	// Skip auto-discovery when the user explicitly specified enterprises, organizations, or repositories.
-	return len(ctx.Params.Enterprises) > 0 ||
+	// Skip auto-discovery when the user explicitly specified enterprises, organizations, or repositories,
+	// or when replaying from a JSON file.
+	return ctx.Params.FromJSON != "" ||
+		len(ctx.Params.Enterprises) > 0 ||
 		len(ctx.Params.Organizations) > 0 ||
 		len(ctx.Params.Repositories) > 0
 }

--- a/internal/pipeline/stage_initialization.go
+++ b/internal/pipeline/stage_initialization.go
@@ -47,5 +47,6 @@ func (s *InitializationStage) Execute(ctx *ScanContext) error {
 }
 
 func (s *InitializationStage) Skip(ctx *ScanContext) bool {
-	return false
+	// Skip GitHub authentication and client setup when replaying from a JSON file.
+	return ctx.Params != nil && ctx.Params.FromJSON != ""
 }

--- a/internal/pipeline/stage_load_json.go
+++ b/internal/pipeline/stage_load_json.go
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog/log"
+)
+
+// LoadFromJSONStage replays a previous scan by loading its JSON output into
+// ctx.Results. When active, all scanning stages skip themselves so that only
+// evaluation and report rendering run against the loaded data.
+type LoadFromJSONStage struct {
+	*BaseStage
+}
+
+// NewLoadFromJSONStage creates a new load-from-json stage.
+func NewLoadFromJSONStage() *LoadFromJSONStage {
+	return &LoadFromJSONStage{
+		BaseStage: NewBaseStage("load-from-json"),
+	}
+}
+
+// embeddedEvalFields lists fields the JSON renderer embeds into entities from
+// prior evaluation runs. They are stripped on load so a replay produces a
+// clean output instead of nesting evaluations inside evaluations.
+var embeddedEvalFields = []string{
+	"evaluation",
+	"copilot_evaluation",
+	"actions_permissions_evaluation",
+	"org_security_alerts_evaluation",
+	"security_managers_evaluation",
+	"enterprise_security_alerts_evaluation",
+	"enterprise_ghas_evaluation",
+	"org_security_defaults_evaluation",
+	"audit_log_evaluation",
+	"metadata_evaluation",
+	"collaborators_evaluation",
+	"deploy_keys_evaluation",
+	"dependabot_evaluation",
+	"code_scanning_evaluation",
+	"discussions_evaluation",
+}
+
+func (s *LoadFromJSONStage) Execute(ctx *ScanContext) error {
+	path := ctx.Params.FromJSON
+	log.Info().Str("path", path).Msg("Replaying scan from JSON; GitHub API calls will be skipped")
+
+	data, err := os.ReadFile(path) // #nosec G304 -- user-supplied input file is the documented interface
+	if err != nil {
+		return fmt.Errorf("failed to read --from-json file %q: %w", path, err)
+	}
+
+	var report struct {
+		Enterprises   map[string]interface{} `json:"enterprises"`
+		Organizations map[string]interface{} `json:"organizations"`
+		Repositories  map[string]interface{} `json:"repositories"`
+	}
+	if err := json.Unmarshal(data, &report); err != nil {
+		return fmt.Errorf("failed to parse --from-json file %q: %w", path, err)
+	}
+
+	loaded := loadEntities(ctx, "enterprise:", report.Enterprises) +
+		loadEntities(ctx, "organization:", report.Organizations) +
+		loadEntities(ctx, "repository:", report.Repositories)
+
+	if loaded == 0 {
+		return fmt.Errorf("no entities found in %q (expected 'enterprises', 'organizations', or 'repositories' keys)", path)
+	}
+
+	// Warn once about lossy fields that the JSON renderer compacts on output.
+	for _, entity := range report.Repositories {
+		if m, ok := entity.(map[string]interface{}); ok {
+			if _, has := m["collaborator_summary"]; has {
+				log.Warn().Msg("Replay input contains 'collaborator_summary' (compacted); per-collaborator rules will not be re-evaluated")
+				break
+			}
+		}
+	}
+
+	log.Info().
+		Int("enterprises", len(report.Enterprises)).
+		Int("organizations", len(report.Organizations)).
+		Int("repositories", len(report.Repositories)).
+		Msg("Replay data loaded")
+	return nil
+}
+
+func loadEntities(ctx *ScanContext, prefix string, entities map[string]interface{}) int {
+	count := 0
+	for name, raw := range entities {
+		m, ok := raw.(map[string]interface{})
+		if !ok {
+			log.Warn().Str("entity", prefix+name).Msg("Skipping entity with unexpected JSON shape")
+			continue
+		}
+		for _, field := range embeddedEvalFields {
+			delete(m, field)
+		}
+		ctx.Results[prefix+name] = m
+		count++
+	}
+	return count
+}
+
+// Skip returns true when --from-json is not supplied.
+func (s *LoadFromJSONStage) Skip(ctx *ScanContext) bool {
+	return ctx.Params == nil || ctx.Params.FromJSON == ""
+}

--- a/internal/pipeline/stage_load_json_test.go
+++ b/internal/pipeline/stage_load_json_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package pipeline
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/ghqr/internal/models"
+)
+
+func TestLoadFromJSONStage_Skip(t *testing.T) {
+	stage := NewLoadFromJSONStage()
+
+	ctxEmpty := &ScanContext{Params: &models.ScanParams{}}
+	if !stage.Skip(ctxEmpty) {
+		t.Fatal("expected Skip=true when FromJSON is empty")
+	}
+
+	ctxSet := &ScanContext{Params: &models.ScanParams{FromJSON: "x.json"}}
+	if stage.Skip(ctxSet) {
+		t.Fatal("expected Skip=false when FromJSON is set")
+	}
+}
+
+func TestLoadFromJSONStage_Execute(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "input.json")
+	payload := `{
+		"generated_at": "2026-04-17T14:34:26Z",
+		"organizations": {
+			"acme": {
+				"settings": {"login": "acme"},
+				"evaluation": {"stale": true},
+				"copilot_evaluation": {"stale": true}
+			}
+		},
+		"repositories": {
+			"acme/widget": {
+				"access": {"archived": false},
+				"evaluation": {"stale": true},
+				"collaborator_summary": {"admin": 2}
+			}
+		},
+		"enterprises": {
+			"acme-ent": {"slug": "acme-ent"}
+		}
+	}`
+	if err := os.WriteFile(path, []byte(payload), 0600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	scanCtx := &ScanContext{
+		Ctx:     context.Background(),
+		Params:  &models.ScanParams{FromJSON: path},
+		Results: map[string]interface{}{},
+	}
+
+	stage := NewLoadFromJSONStage()
+	if err := stage.Execute(scanCtx); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	for _, key := range []string{"organization:acme", "repository:acme/widget", "enterprise:acme-ent"} {
+		if _, ok := scanCtx.Results[key]; !ok {
+			t.Errorf("missing key %q in Results", key)
+		}
+	}
+
+	org := scanCtx.Results["organization:acme"].(map[string]interface{})
+	if _, has := org["evaluation"]; has {
+		t.Error("expected embedded 'evaluation' field to be stripped from organization")
+	}
+	if _, has := org["copilot_evaluation"]; has {
+		t.Error("expected embedded 'copilot_evaluation' field to be stripped from organization")
+	}
+
+	repo := scanCtx.Results["repository:acme/widget"].(map[string]interface{})
+	if _, has := repo["evaluation"]; has {
+		t.Error("expected embedded 'evaluation' field to be stripped from repository")
+	}
+}
+
+func TestLoadFromJSONStage_Execute_MissingFile(t *testing.T) {
+	scanCtx := &ScanContext{
+		Ctx:     context.Background(),
+		Params:  &models.ScanParams{FromJSON: filepath.Join(t.TempDir(), "missing.json")},
+		Results: map[string]interface{}{},
+	}
+	if err := NewLoadFromJSONStage().Execute(scanCtx); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadFromJSONStage_Execute_EmptyReport(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.json")
+	if err := os.WriteFile(path, []byte(`{}`), 0600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	scanCtx := &ScanContext{
+		Ctx:     context.Background(),
+		Params:  &models.ScanParams{FromJSON: path},
+		Results: map[string]interface{}{},
+	}
+	if err := NewLoadFromJSONStage().Execute(scanCtx); err == nil {
+		t.Fatal("expected error for empty report")
+	}
+}
+
+func TestNewScanContext_ReplayOutputName(t *testing.T) {
+	params := &models.ScanParams{FromJSON: "/tmp/myscan.json"}
+	ctx := NewScanContext(params)
+	if got := ctx.OutputName; len(got) == 0 || got[:len("myscan_replay_")] != "myscan_replay_" {
+		t.Fatalf("expected output name to start with 'myscan_replay_', got %q", got)
+	}
+}

--- a/internal/pipeline/stage_org_repository_scan.go
+++ b/internal/pipeline/stage_org_repository_scan.go
@@ -96,6 +96,9 @@ func (s *OrgRepositoryScanStage) Execute(ctx *ScanContext) error {
 }
 
 func (s *OrgRepositoryScanStage) Skip(ctx *ScanContext) bool {
+	if ctx.Params != nil && ctx.Params.FromJSON != "" {
+		return true
+	}
 	for key := range ctx.Results {
 		if strings.HasPrefix(key, "organization:") {
 			return false

--- a/internal/pipeline/stage_organization_discovery.go
+++ b/internal/pipeline/stage_organization_discovery.go
@@ -56,8 +56,9 @@ func (s *OrganizationDiscoveryStage) Execute(ctx *ScanContext) error {
 }
 
 func (s *OrganizationDiscoveryStage) Skip(ctx *ScanContext) bool {
-	// Skip auto-discovery when organizations are already specified or when
-	// only specific repositories were requested (no need to discover orgs).
-	return len(ctx.Params.Organizations) > 0 ||
+	// Skip auto-discovery when organizations are already specified, when only specific
+	// repositories were requested, or when replaying from a JSON file.
+	return ctx.Params.FromJSON != "" ||
+		len(ctx.Params.Organizations) > 0 ||
 		len(ctx.Params.Repositories) > 0
 }


### PR DESCRIPTION
This pull request introduces a new feature that allows users to replay the enrichment and report generation steps of a scan using a previously saved JSON scan file, without making any GitHub API calls. This enables faster iteration on evaluation rules and report rendering. The implementation includes a new pipeline stage, command-line flag, documentation updates, and comprehensive tests. Notably, it ensures that replaying is mutually exclusive with specifying new scan targets and gracefully handles lossy fields in the replayed JSON.

**Replay/Enrichment from Previous Scan:**

* Added a `--from-json` flag to the `ghqr scan` command, allowing users to replay enrichment and report rendering from an existing scan JSON file without contacting the GitHub API. The flag is documented in both the CLI and `README.md`. [[1]](diffhunk://#diff-c2c9ae9afae9ef55e3d27d0555d5a77ed360fe90b0dd91fbdf5fd19a138ec8a0R24) [[2]](diffhunk://#diff-c2c9ae9afae9ef55e3d27d0555d5a77ed360fe90b0dd91fbdf5fd19a138ec8a0L56-R60) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R119-R128)
* Updated input validation to prevent combining `--from-json` with target selection flags (`-e/--enterprise`, `-o/--organization`, `-r/--repository`), and to verify the input file is accessible.

**Pipeline and Stage Management:**

* Introduced a new `LoadFromJSONStage` pipeline stage that loads scan results from a JSON file, strips embedded evaluation fields to avoid nesting, and populates the pipeline context for further enrichment and report rendering. This stage is conditionally added to the pipeline and includes logic to skip all GitHub API-dependent stages when active. [[1]](diffhunk://#diff-6ae08ebc7a59fd0771f20904b40dd84c46de426d82d556362f8289a2047cca05R1-R113) [[2]](diffhunk://#diff-51765a7a2666111a77c05ed444441bab7983e775b1fd8a3e78f5224c4b86bcb5R38-R43) [[3]](diffhunk://#diff-51765a7a2666111a77c05ed444441bab7983e775b1fd8a3e78f5224c4b86bcb5R93) [[4]](diffhunk://#diff-51765a7a2666111a77c05ed444441bab7983e775b1fd8a3e78f5224c4b86bcb5R112-R119) [[5]](diffhunk://#diff-b4af08f33ebc2b8b3036060bfa87f9ff6b4ecf5debb94c78f74bd49f16a50f5eR15-R18)
* Modified the skip logic in all relevant pipeline stages to ensure they are bypassed when replaying from a JSON file, including initialization, discovery, and scanning stages. [[1]](diffhunk://#diff-f2afa5b266eb5555b9fb3ebc33f27e7bcab0b37016026730e0ea7909b2e67d9fL50-R51) [[2]](diffhunk://#diff-c01c6c8166528dbb27259e06faf57c2d63d85abc40cbb051686a5c799fc98fc2L79-R82) [[3]](diffhunk://#diff-9fcf1e9e335a3ae8758c78ec174eb1410378c8dcb402871d4690ac5603b6a1daL59-R62) [[4]](diffhunk://#diff-a1c7bef37a22e55dd74aa47d62e2169e36be3accdbb00f9a4c91a7cac19a5f03R99-R101)

**Testing and Robustness:**

* Added comprehensive tests for the new replay stage, including tests for correct field stripping, error handling for missing or empty files, and output naming conventions when replaying.

These changes collectively provide a robust and user-friendly way to iterate on scan evaluations and reports without redundant API calls, improving both developer workflow and tool efficiency.