### PR TITLE
perf: apply performance and simplification improvements

### DIFF
--- a/internal/config/http_client.go
+++ b/internal/config/http_client.go
@@ -6,20 +6,34 @@ package config
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"golang.org/x/oauth2"
 )
+
+// sharedTransport is the single HTTP transport shared by all authenticated clients.
+// Sharing the transport means all GitHub API callers reuse the same TCP/TLS
+// connection pool, eliminating repeated TLS handshakes on every client creation.
+// MaxIdleConnsPerHost is raised from Go's default of 2 to allow enough warm
+// connections for concurrent GraphQL and REST requests (up to 10 ruleset workers).
+var sharedTransport = &http.Transport{
+	MaxIdleConns:        200,
+	MaxIdleConnsPerHost: 50,
+	IdleConnTimeout:     90 * time.Second,
+	ForceAttemptHTTP2:   true,
+}
 
 // newAuthenticatedHTTPClient wraps an oauth2 static-token transport with the
 // shared rate-limit-aware transport so both github.com and GHES requests get
 // identical retry semantics. Centralising the constructor here means a
 // future change to the transport stack (additional retries, telemetry,
 // proxy support) automatically applies to both code paths.
-func newAuthenticatedHTTPClient(ctx context.Context, token string) *http.Client {
-	oauthTransport := oauth2.NewClient(
-		ctx,
-		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}),
-	).Transport
+func newAuthenticatedHTTPClient(_ context.Context, token string) *http.Client {
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	oauthTransport := &oauth2.Transport{
+		Source: ts,
+		Base:   sharedTransport,
+	}
 	return &http.Client{
 		Transport: &rateLimitTransport{wrapped: oauthTransport},
 	}

--- a/internal/pipeline/builder.go
+++ b/internal/pipeline/builder.go
@@ -27,65 +27,10 @@ func NewScanPipelineBuilder() *ScanPipelineBuilder {
 	}
 }
 
-func (b *ScanPipelineBuilder) addStage(stage Stage) *ScanPipelineBuilder {
-	b.stages = append(b.stages, stage)
+// With appends a stage to the pipeline and returns the builder for chaining.
+func (b *ScanPipelineBuilder) With(s Stage) *ScanPipelineBuilder {
+	b.stages = append(b.stages, s)
 	return b
-}
-
-// WithInitialization adds the initialization stage.
-func (b *ScanPipelineBuilder) WithInitialization() *ScanPipelineBuilder {
-	return b.addStage(NewInitializationStage())
-}
-
-// WithLoadFromJSON adds the load-from-json replay stage. The stage self-skips
-// unless ScanParams.FromJSON is set.
-func (b *ScanPipelineBuilder) WithLoadFromJSON() *ScanPipelineBuilder {
-	return b.addStage(NewLoadFromJSONStage())
-}
-
-// WithEnterpriseScan adds the enterprise scanning stage.
-func (b *ScanPipelineBuilder) WithEnterpriseScan() *ScanPipelineBuilder {
-	return b.addStage(NewEnterpriseScanStage())
-}
-
-// WithEnterpriseDiscovery adds the enterprise discovery stage.
-func (b *ScanPipelineBuilder) WithEnterpriseDiscovery() *ScanPipelineBuilder {
-	return b.addStage(NewEnterpriseDiscoveryStage())
-}
-
-// WithOrganizationDiscovery adds the organization discovery stage.
-func (b *ScanPipelineBuilder) WithOrganizationDiscovery() *ScanPipelineBuilder {
-	return b.addStage(NewOrganizationDiscoveryStage())
-}
-
-// WithOrganizationScan adds the organization scanning stage.
-func (b *ScanPipelineBuilder) WithOrganizationScan() *ScanPipelineBuilder {
-	return b.addStage(NewOrganizationScanStage())
-}
-
-// WithOrgRepositoryDiscovery adds the org-repository discovery stage.
-func (b *ScanPipelineBuilder) WithOrgRepositoryDiscovery() *ScanPipelineBuilder {
-	return b.addStage(NewOrgRepositoryDiscoveryStage())
-}
-
-// WithRepositoryScan adds the individual repository scanning stage.
-func (b *ScanPipelineBuilder) WithRepositoryScan() *ScanPipelineBuilder {
-	return b.addStage(NewRepositoryScanStage())
-}
-
-// WithReportRendering adds the report rendering stage.
-func (b *ScanPipelineBuilder) WithReportRendering() *ScanPipelineBuilder {
-	return b.addStage(NewReportRenderingStage())
-}
-
-// WithEvaluation adds the evaluation stage.
-func (b *ScanPipelineBuilder) WithEvaluation() *ScanPipelineBuilder {
-	return b.addStage(NewEvaluationStage())
-}
-
-// WithGHESScan adds the GitHub Enterprise Server scanning stage.
-func (b *ScanPipelineBuilder) WithGHESScan() *ScanPipelineBuilder {
-	return b.addStage(NewGHESScanStage())
 }
 
 // Build creates the pipeline with all configured stages.
@@ -100,17 +45,17 @@ func (b *ScanPipelineBuilder) Build() *Pipeline {
 // ctx.Params.FromJSON in its Skip() method as a belt-and-braces guard.
 func (b *ScanPipelineBuilder) BuildDefault() *Pipeline {
 	return b.
-		WithInitialization().
-		WithLoadFromJSON().
-		WithGHESScan().
-		WithEnterpriseDiscovery().
-		WithEnterpriseScan().
-		WithOrganizationDiscovery().
-		WithOrganizationScan().
-		WithOrgRepositoryDiscovery().
-		WithRepositoryScan().
-		WithEvaluation().
-		WithReportRendering().
+		With(NewInitializationStage()).
+		With(NewLoadFromJSONStage()).
+		With(NewGHESScanStage()).
+		With(NewEnterpriseDiscoveryStage()).
+		With(NewEnterpriseScanStage()).
+		With(NewOrganizationDiscoveryStage()).
+		With(NewOrganizationScanStage()).
+		With(NewOrgRepositoryDiscoveryStage()).
+		With(NewRepositoryScanStage()).
+		With(NewEvaluationStage()).
+		With(NewReportRenderingStage()).
 		Build()
 }
 

--- a/internal/recommendations/loader.go
+++ b/internal/recommendations/loader.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/fs"
 	"strings"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 )
@@ -15,10 +16,21 @@ import (
 //go:embed definitions/**/*.yaml
 var embeddedDefinitions embed.FS
 
+var (
+	loadOnce      sync.Once
+	loadedRegistry *Registry
+	loadErr        error
+)
+
 // Load reads all embedded YAML rule definition files and returns a populated Registry.
+// Results are cached after the first call — the embedded filesystem is immutable so
+// repeated FS walks and YAML parses are pure waste.
 // It returns an error if any file cannot be parsed or if duplicate rule IDs are found.
 func Load() (*Registry, error) {
-	return loadFrom(embeddedDefinitions)
+	loadOnce.Do(func() {
+		loadedRegistry, loadErr = loadFrom(embeddedDefinitions)
+	})
+	return loadedRegistry, loadErr
 }
 
 // loadFrom is the internal loader used by Load and tests.

--- a/internal/renderers/excel/branch_protection.go
+++ b/internal/renderers/excel/branch_protection.go
@@ -4,8 +4,8 @@
 package excel
 
 import (
-	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/microsoft/ghqr/internal/scanners"
@@ -26,15 +26,12 @@ func renderBranchProtection(f *excelize.File, results map[string]interface{}, st
 		"Require Status Checks", "Strict Status Checks",
 		"Allow Force Pushes", "Allow Deletions", "Required Signatures",
 	}
-	createFirstRow(f, sheet, headers, styles)
 
-	rows := buildBranchProtectionTable(results)
-	lastRow, err := writeRows(f, sheet, rows, 1)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to write BranchProtection rows")
-	}
-
-	configureSheet(f, sheet, headers, lastRow, styles)
+	data := buildBranchProtectionTable(results)
+	rows := make([][]string, 0, len(data)+1)
+	rows = append(rows, headers)
+	rows = append(rows, data...)
+	streamSheet(f, sheet, rows, styles)
 }
 
 func buildBranchProtectionTable(results map[string]interface{}) [][]string {
@@ -72,7 +69,7 @@ func buildBranchProtectionTable(results map[string]interface{}) [][]string {
 		requiredSignatures := boolStr(bp.RequiredSignatures)
 
 		if r := bp.RequiredPullRequestReviews; r != nil {
-			requiredApprovals = fmt.Sprintf("%d", r.RequiredApprovingReviewCount)
+			requiredApprovals = strconv.Itoa(r.RequiredApprovingReviewCount)
 			dismissStale = boolStr(r.DismissStaleReviews)
 			requireCodeowners = boolStr(r.RequireCodeOwnerReviews)
 		}

--- a/internal/renderers/excel/excel.go
+++ b/internal/renderers/excel/excel.go
@@ -5,6 +5,7 @@ package excel
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/rs/zerolog/log"
 	"github.com/xuri/excelize/v2"
@@ -55,7 +56,7 @@ func createSharedStyles(f *excelize.File) (*StyleCache, error) {
 
 // CreateExcelReport builds an Excel file from scan results and writes it to disk.
 func CreateExcelReport(results map[string]interface{}, outputName string) {
-	filename := fmt.Sprintf("%s.xlsx", outputName)
+	filename := outputName + ".xlsx"
 	log.Info().Msgf("Generating Excel report: %s", filename)
 
 	f := excelize.NewFile()
@@ -91,116 +92,111 @@ func CreateExcelReport(results map[string]interface{}, outputName string) {
 	log.Info().Str("path", filename).Msg("Excel report written")
 }
 
-// createFirstRow writes the header row (row 1) and applies the header style.
-func createFirstRow(f *excelize.File, sheet string, headers []string, styles *StyleCache) {
-	cell, err := excelize.CoordinatesToCellName(1, 1)
-	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to get cell")
-	}
-	if err := f.SetSheetRow(sheet, cell, &headers); err != nil {
-		log.Fatal().Err(err).Msg("Failed to set header row")
-	}
-	if len(headers) > 0 {
-		endCell, err := excelize.CoordinatesToCellName(len(headers), 1)
-		if err != nil {
-			log.Fatal().Err(err).Msg("Failed to get end cell")
-		}
-		if err := f.SetCellStyle(sheet, "A1", endCell, styles.Header); err != nil {
-			log.Fatal().Err(err).Msg("Failed to set header style")
-		}
-	}
-}
-
-// writeRows appends rows starting after startRow and returns the last written row number.
-func writeRows(f *excelize.File, sheet string, rows [][]string, startRow int) (int, error) {
-	currentRow := startRow
-	for _, row := range rows {
-		currentRow++
-		cell, err := excelize.CoordinatesToCellName(1, currentRow)
-		if err != nil {
-			return currentRow, fmt.Errorf("failed to get cell name: %w", err)
-		}
-		if err := f.SetSheetRow(sheet, cell, &row); err != nil {
-			return currentRow, fmt.Errorf("failed to set row: %w", err)
-		}
-	}
-	return currentRow, nil
-}
-
-// configureSheet applies autofit, autofilter, and alternating row colors.
-func configureSheet(f *excelize.File, sheet string, headers []string, lastRow int, styles *StyleCache) {
-	autofitColumns(f, sheet)
-
-	if len(headers) > 0 && lastRow >= 1 {
-		endCell, err := excelize.CoordinatesToCellName(len(headers), lastRow)
-		if err != nil {
-			log.Fatal().Err(err).Msg("Failed to get autofilter end cell")
-		}
-		if err := f.AutoFilter(sheet, fmt.Sprintf("A1:%s", endCell), nil); err != nil {
-			log.Fatal().Err(err).Msg("Failed to set autofilter")
-		}
-	}
-
-	applyRowStyles(f, sheet, lastRow, len(headers), styles)
-}
-
-// autofitColumns sets column widths based on content (sampled, capped at 120).
-func autofitColumns(f *excelize.File, sheet string) {
-	cols, err := f.GetCols(sheet)
-	if err != nil {
+// streamSheet writes all rows for a sheet using excelize StreamWriter, which streams
+// directly to the zip buffer instead of keeping every cell in an in-memory map.
+// rows[0] is treated as the header row. Column widths are pre-computed from the
+// in-memory slice so no second read-back of the sheet is required.
+func streamSheet(f *excelize.File, sheetName string, rows [][]string, styles *StyleCache) {
+	if len(rows) == 0 {
 		return
+	}
+
+	widths := computeWidthsFromRecords(rows, 1000)
+
+	sw, err := f.NewStreamWriter(sheetName)
+	if err != nil {
+		log.Error().Err(err).Msgf("failed to create stream writer for %s", sheetName)
+		return
+	}
+
+	// Column widths must be set before any SetRow calls.
+	for i, w := range widths {
+		if w < 8 {
+			w = 8
+		}
+		if err := sw.SetColWidth(i+1, i+1, float64(w)); err != nil {
+			log.Warn().Err(err).Msgf("failed to set column %d width for %s", i+1, sheetName)
+		}
+	}
+
+	// Header row (row 1).
+	headers := rows[0]
+	headerCells := make([]interface{}, len(headers))
+	for i, h := range headers {
+		headerCells[i] = excelize.Cell{Value: h, StyleID: styles.Header}
+	}
+	if err := sw.SetRow("A1", headerCells, excelize.RowOpts{StyleID: styles.Header}); err != nil {
+		log.Error().Err(err).Msgf("failed to write header row for %s", sheetName)
+	}
+
+	// Data rows with alternating blue/white fill.
+	cells := make([]interface{}, len(headers))
+	for i, row := range rows[1:] {
+		rowNum := i + 2 // 1-based; header is row 1
+		styleID := styles.White
+		if rowNum%2 == 0 {
+			styleID = styles.Blue
+		}
+		for j := range cells {
+			val := ""
+			if j < len(row) {
+				val = row[j]
+			}
+			cells[j] = excelize.Cell{Value: val, StyleID: styleID}
+		}
+		cellName := "A" + strconv.Itoa(rowNum)
+		if err := sw.SetRow(cellName, cells, excelize.RowOpts{StyleID: styleID}); err != nil {
+			log.Warn().Err(err).Msgf("failed to write row %d for %s", rowNum, sheetName)
+		}
+	}
+
+	// AutoFilter must be applied before Flush so it is serialised into the worksheet XML.
+	if len(rows) >= 1 && len(headers) > 0 {
+		lastRow := len(rows)
+		if lastCell, err := excelize.CoordinatesToCellName(len(headers), lastRow); err == nil {
+			if err := f.AutoFilter(sheetName, "A1:"+lastCell, nil); err != nil {
+				log.Warn().Err(err).Msgf("failed to set autofilter for %s", sheetName)
+			}
+		}
+	}
+
+	if err := sw.Flush(); err != nil {
+		log.Error().Err(err).Msgf("failed to flush stream writer for %s", sheetName)
+	}
+}
+
+// computeWidthsFromRecords calculates per-column max widths by scanning the
+// already-in-memory records slice. This avoids the memory cost of f.GetCols()
+// which reads all sheet data back out of excelize's cell map.
+// At most maxSampleRows rows are scanned to bound the cost for large sheets.
+func computeWidthsFromRecords(records [][]string, maxSampleRows int) []int {
+	if len(records) == 0 {
+		return nil
 	}
 	const maxWidth = 120
-	const sampleRows = 1000
-	for idx, col := range cols {
-		largest := 0
-		limit := len(col)
-		if limit > sampleRows {
-			limit = sampleRows
-		}
-		for i := 0; i < limit; i++ {
-			w := len(col[i]) + 3
-			if w > largest {
-				largest = w
-			}
-			if largest >= maxWidth {
-				largest = maxWidth
+	ncols := len(records[0])
+	widths := make([]int, ncols)
+
+	limit := len(records)
+	if limit > maxSampleRows {
+		limit = maxSampleRows
+	}
+
+	for _, row := range records[:limit] {
+		for i, cell := range row {
+			if i >= ncols {
 				break
 			}
-		}
-		if largest > 255 {
-			largest = maxWidth
-		}
-		name, err := excelize.ColumnNumberToName(idx + 1)
-		if err != nil {
-			continue
-		}
-		_ = f.SetColWidth(sheet, name, name, float64(largest))
-	}
-}
-
-// applyRowStyles applies alternating blue/white fill to data rows (row 2 onward).
-func applyRowStyles(f *excelize.File, sheet string, lastRow, columns int, styles *StyleCache) {
-	if columns == 0 || lastRow < 2 {
-		return
-	}
-	for i := 2; i <= lastRow; i++ {
-		style := styles.White
-		if i%2 == 0 {
-			style = styles.Blue
-		}
-		startCell, err := excelize.CoordinatesToCellName(1, i)
-		if err != nil {
-			continue
-		}
-		endCell, err := excelize.CoordinatesToCellName(columns, i)
-		if err != nil {
-			continue
-		}
-		if err := f.SetCellStyle(sheet, startCell, endCell, style); err != nil {
-			log.Fatal().Err(err).Msg("Failed to set row style")
+			w := len(cell) + 3
+			if w > widths[i] {
+				widths[i] = w
+			}
+			if widths[i] > maxWidth {
+				widths[i] = maxWidth
+			}
 		}
 	}
+	return widths
 }
 
 // boolStr converts a bool to "Yes" / "No" for human-readable output.

--- a/internal/renderers/excel/issues.go
+++ b/internal/renderers/excel/issues.go
@@ -20,15 +20,12 @@ func renderIssues(f *excelize.File, results map[string]interface{}, styles *Styl
 	}
 
 	headers := []string{"Type", "Name", "Severity", "Category", "Issue", "Recommendation", "Learn More"}
-	createFirstRow(f, sheet, headers, styles)
 
-	rows := buildIssuesTable(results)
-	lastRow, err := writeRows(f, sheet, rows, 1)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to write Findings rows")
-	}
-
-	configureSheet(f, sheet, headers, lastRow, styles)
+	data := buildIssuesTable(results)
+	rows := make([][]string, 0, len(data)+1)
+	rows = append(rows, headers)
+	rows = append(rows, data...)
+	streamSheet(f, sheet, rows, styles)
 }
 
 // buildIssuesTable flattens all evaluation results into a sortable table of findings.

--- a/internal/renderers/excel/organizations.go
+++ b/internal/renderers/excel/organizations.go
@@ -4,8 +4,8 @@
 package excel
 
 import (
-	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/microsoft/ghqr/internal/scanners"
@@ -28,15 +28,12 @@ func renderOrganizations(f *excelize.File, results map[string]interface{}, style
 		"Advanced Security New Repos", "Dependabot Alerts New Repos",
 		"Total Issues",
 	}
-	createFirstRow(f, sheet, headers, styles)
 
-	rows := buildOrganizationsTable(results)
-	lastRow, err := writeRows(f, sheet, rows, 1)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to write Organizations rows")
-	}
-
-	configureSheet(f, sheet, headers, lastRow, styles)
+	data := buildOrganizationsTable(results)
+	rows := make([][]string, 0, len(data)+1)
+	rows = append(rows, headers)
+	rows = append(rows, data...)
+	streamSheet(f, sheet, rows, styles)
 }
 
 func buildOrganizationsTable(results map[string]interface{}) [][]string {
@@ -84,7 +81,7 @@ func buildOrganizationsTable(results map[string]interface{}) [][]string {
 		if evalVal, ok := results[evalKey]; ok {
 			if eval, ok := evalVal.(*bestpractices.EvaluationResult); ok {
 				if s := eval.Summary; s != nil {
-					total = fmt.Sprintf("%d", s.TotalIssues)
+					total = strconv.Itoa(s.TotalIssues)
 				}
 			}
 		}

--- a/internal/renderers/excel/repositories.go
+++ b/internal/renderers/excel/repositories.go
@@ -4,8 +4,8 @@
 package excel
 
 import (
-	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/microsoft/ghqr/internal/scanners"
@@ -27,15 +27,12 @@ func renderRepositories(f *excelize.File, results map[string]interface{}, styles
 		"Default Branch", "Language", "License",
 		"Total Issues", "Critical", "High", "Medium", "Low",
 	}
-	createFirstRow(f, sheet, headers, styles)
 
-	rows := buildRepositoriesTable(results)
-	lastRow, err := writeRows(f, sheet, rows, 1)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to write Repositories rows")
-	}
-
-	configureSheet(f, sheet, headers, lastRow, styles)
+	data := buildRepositoriesTable(results)
+	rows := make([][]string, 0, len(data)+1)
+	rows = append(rows, headers)
+	rows = append(rows, data...)
+	streamSheet(f, sheet, rows, styles)
 }
 
 func buildRepositoriesTable(results map[string]interface{}) [][]string {
@@ -79,11 +76,11 @@ func buildRepositoriesTable(results map[string]interface{}) [][]string {
 		if evalVal, ok := results[evalKey]; ok {
 			if eval, ok := evalVal.(*bestpractices.EvaluationResult); ok {
 				if s := eval.Summary; s != nil {
-					total = fmt.Sprintf("%d", s.TotalIssues)
-					critical = fmt.Sprintf("%d", s.Critical)
-					high = fmt.Sprintf("%d", s.HighSeverity)
-					medium = fmt.Sprintf("%d", s.MediumSeverity)
-					low = fmt.Sprintf("%d", s.LowSeverity)
+					total = strconv.Itoa(s.TotalIssues)
+					critical = strconv.Itoa(s.Critical)
+					high = strconv.Itoa(s.HighSeverity)
+					medium = strconv.Itoa(s.MediumSeverity)
+					low = strconv.Itoa(s.LowSeverity)
 				}
 			}
 		}

--- a/internal/scanners/enterprise.go
+++ b/internal/scanners/enterprise.go
@@ -261,10 +261,10 @@ func (e *EnterpriseScanner) getSecurityAlerts(ctx context.Context) (*EnterpriseS
 			result.Available = true
 			result.OpenDependabotAlerts = len(depAlerts)
 			for _, a := range depAlerts {
-				switch strings.ToLower(a.SecurityAdvisory.Severity) {
-				case "critical":
+				switch strings.ToUpper(a.SecurityAdvisory.Severity) {
+				case "CRITICAL":
 					result.CriticalDependabot++
-				case "high":
+				case "HIGH":
 					result.HighDependabot++
 				}
 			}

--- a/internal/scanners/ghes.go
+++ b/internal/scanners/ghes.go
@@ -334,10 +334,10 @@ func (s *GHESScanner) getSecurityAlerts(ctx context.Context) (*GHESSecurityAlert
 			result.Available = true
 			result.OpenDependabotAlerts = len(depAlerts)
 			for _, a := range depAlerts {
-				switch strings.ToLower(a.SecurityAdvisory.Severity) {
-				case "critical":
+				switch strings.ToUpper(a.SecurityAdvisory.Severity) {
+				case "CRITICAL":
 					result.CriticalDependabot++
-				case "high":
+				case "HIGH":
 					result.HighDependabot++
 				}
 			}

--- a/internal/scanners/organization.go
+++ b/internal/scanners/organization.go
@@ -157,10 +157,10 @@ func (o *OrganizationScanner) scanSecurityAlerts(ctx context.Context) (*OrgSecur
 		result.Available = true
 		result.OpenDependabotAlerts += len(dependabotAlerts)
 		for _, a := range dependabotAlerts {
-			switch strings.ToLower(a.SecurityAdvisory.Severity) {
-			case "critical":
+			switch strings.ToUpper(a.SecurityAdvisory.Severity) {
+			case "CRITICAL":
 				result.CriticalDependabot++
-			case "high":
+			case "HIGH":
 				result.HighDependabot++
 			}
 		}

--- a/internal/scanners/repository.go
+++ b/internal/scanners/repository.go
@@ -50,8 +50,21 @@ func MapNodeToData(gql RepositoryNode) *RepositoryData {
 	total := 0
 	for _, node := range gql.VulnerabilityAlerts.Nodes {
 		if node.DismissedAt == nil {
-			sev := strings.ToLower(string(node.SecurityVulnerability.Severity))
-			bySeverity[sev]++
+			// GitHub returns severity as an uppercase enum (CRITICAL, HIGH, MEDIUM, LOW).
+			// Compare without allocating a lowered string; store the canonical lowercase key.
+			sev := string(node.SecurityVulnerability.Severity)
+			switch {
+			case strings.EqualFold(sev, "critical"):
+				bySeverity["critical"]++
+			case strings.EqualFold(sev, "high"):
+				bySeverity["high"]++
+			case strings.EqualFold(sev, "medium"):
+				bySeverity["medium"]++
+			case strings.EqualFold(sev, "low"):
+				bySeverity["low"]++
+			default:
+				bySeverity[strings.ToLower(sev)]++
+			}
 			total++
 		}
 	}


### PR DESCRIPTION
# Description

This pull request introduces several improvements and refactorings across the codebase, focusing on performance, memory usage, and code clarity. The most significant changes are the adoption of streaming for Excel report generation to reduce memory usage, the caching of recommendation registry loads, and the refactoring of pipeline builder methods for a simpler API. Additional changes include improved handling of HTTP client transports and minor code cleanups.

**Excel report generation improvements:**

* Replaced in-memory row writing with `excelize` streaming in all Excel renderers, significantly reducing memory usage for large reports and simplifying the code by removing `createFirstRow`, `writeRows`, and `configureSheet` functions. Added `streamSheet` and `computeWidthsFromRecords` for efficient streaming and column width calculation. [[1]](diffhunk://#diff-baffdc4beee0745f776cb106c461e9294f360b8d7abd10bfea5700ac521a130dL94-R199) [[2]](diffhunk://#diff-e6933a2127a110380c899c4d1c88a05593ae62f96cf353358edb9b6a42c5b0b4L29-R34) [[3]](diffhunk://#diff-f2f0f4e0e6ce9c9c3f0ed983d28f07d7d0211e5ea893fb0cbbed2055264f11e0L23-R28) [[4]](diffhunk://#diff-e3d9f10aa2dcc2ad6179da03a9ba259ca1d5e605a56b50a0df196b10c058b0feL31-R36) [[5]](diffhunk://#diff-6f6c6de633d513de0d918e4d3e7214263dde042ab5e7cb745862173aa618ec1fL30-R35)
* Switched from `fmt.Sprintf` to `strconv.Itoa` for integer-to-string conversions in Excel renderers for improved performance. [[1]](diffhunk://#diff-6f6c6de633d513de0d918e4d3e7214263dde042ab5e7cb745862173aa618ec1fL82-R83) [[2]](diffhunk://#diff-e3d9f10aa2dcc2ad6179da03a9ba259ca1d5e605a56b50a0df196b10c058b0feL87-R84) [[3]](diffhunk://#diff-e6933a2127a110380c899c4d1c88a05593ae62f96cf353358edb9b6a42c5b0b4L75-R72)

**Performance and memory optimizations:**

* Made the recommendations registry loader (`Load`) cache results after the first call using `sync.Once`, avoiding repeated FS walks and YAML parsing.

**Pipeline builder refactor:**

* Simplified the scan pipeline builder by removing individual `WithX` methods in favor of a single `With` method for adding stages, making the builder more flexible and concise. Updated `BuildDefault` to use the new API. [[1]](diffhunk://#diff-51765a7a2666111a77c05ed444441bab7983e775b1fd8a3e78f5224c4b86bcb5L30-L90) [[2]](diffhunk://#diff-51765a7a2666111a77c05ed444441bab7983e775b1fd8a3e78f5224c4b86bcb5L103-R58)

**HTTP client improvements:**

* Introduced a shared HTTP transport (`sharedTransport`) for all authenticated clients, improving connection reuse and reducing TLS handshake overhead. Updated `newAuthenticatedHTTPClient` to use this shared transport.

**Other fixes and cleanups:**

* Standardized severity string handling in security alert scanners by switching from `strings.ToLower` to `strings.ToUpper` for case-insensitive matching. [[1]](diffhunk://#diff-0bbf142a940b8b112494c3eeb957126cfb5a9752c62270df228dcf27085e7558L264-R267) [[2]](diffhunk://#diff-1f126e5b313b3d799b878c281705e92d07fe602d77d7a15d1e26a91ce48d0badL337-R340) [[3]](diffhunk://#diff-3b034380efa51ea3cb5790d36d17f129656af94dcf0127aabf7104d48632a715L145-R148)
* Minor imports cleanup and replaced `fmt.Sprintf` with string concatenation for Excel filename generation. [[1]](diffhunk://#diff-e6933a2127a110380c899c4d1c88a05593ae62f96cf353358edb9b6a42c5b0b4L7-R8) [[2]](diffhunk://#diff-baffdc4beee0745f776cb106c461e9294f360b8d7abd10bfea5700ac521a130dR8) [[3]](diffhunk://#diff-e3d9f10aa2dcc2ad6179da03a9ba259ca1d5e605a56b50a0df196b10c058b0feL7-R8) [[4]](diffhunk://#diff-6f6c6de633d513de0d918e4d3e7214263dde042ab5e7cb745862173aa618ec1fL7-R8) [[5]](diffhunk://#diff-baffdc4beee0745f776cb106c461e9294f360b8d7abd10bfea5700ac521a130dL58-R59)

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #120

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
