### PR TITLE
feat: optimize markdown report to executive-level format

### DIFF
--- a/internal/renderers/markdown/markdown_categories.go
+++ b/internal/renderers/markdown/markdown_categories.go
@@ -10,18 +10,22 @@ import (
 )
 
 // generateFindingsByCategory groups all findings by category and renders them.
+// Enterprise, GHES, and organization findings are listed individually.
+// Repository findings are deduplicated and aggregated with counts to keep
+// the markdown report at executive-report size.
 func generateFindingsByCategory(allFindings []entityFindings) string {
-	// Group by category.
 	type catFinding struct {
-		Entity string
-		Rec    recommendation
+		Entity     string
+		EntityType string
+		Rec        recommendation
 	}
 	grouped := map[string][]catFinding{}
 	for _, ef := range allFindings {
 		for _, r := range ef.Findings {
 			grouped[r.Category] = append(grouped[r.Category], catFinding{
-				Entity: ef.EntityName,
-				Rec:    r,
+				Entity:     ef.EntityName,
+				EntityType: ef.EntityType,
+				Rec:        r,
 			})
 		}
 	}
@@ -65,39 +69,105 @@ func generateFindingsByCategory(allFindings []entityFindings) string {
 			}
 		}
 
-		// Collect affected entities.
-		entitySet := map[string]bool{}
+		// Compute affected entity counts by type.
+		entitySets := map[string]map[string]bool{}
 		for _, f := range findings {
-			entitySet[f.Entity] = true
+			if entitySets[f.EntityType] == nil {
+				entitySets[f.EntityType] = map[string]bool{}
+			}
+			entitySets[f.EntityType][f.Entity] = true
 		}
-		entities := make([]string, 0, len(entitySet))
-		for e := range entitySet {
-			entities = append(entities, e)
-		}
-		sort.Strings(entities)
+		affectedParts := buildAffectedLabel(entitySets)
 
 		sb.WriteString(fmt.Sprintf("### %s\n\n", displayName))
 		sb.WriteString(fmt.Sprintf("**Risk Level:** %s %s\n", severityEmoji[highestSev], titleCase(highestSev)))
-		sb.WriteString(fmt.Sprintf("**Affected Entities:** %s\n\n", strings.Join(entities, ", ")))
+		sb.WriteString(fmt.Sprintf("**Affected Entities:** %s\n\n", affectedParts))
 
 		sb.WriteString("#### Findings\n\n")
-		sb.WriteString("| Severity | Entity | Finding | Action | Learn More |\n")
-		sb.WriteString("|----------|--------|---------|--------|------------|\n")
 
-		// Sort findings within category by severity.
-		sort.Slice(findings, func(i, j int) bool {
-			return severityOrder[findings[i].Rec.Severity] < severityOrder[findings[j].Rec.Severity]
-		})
-
+		// Separate non-repo findings (shown individually) from repo findings (aggregated).
+		var nonRepoFindings []catFinding
+		var repoFindings []catFinding
 		for _, f := range findings {
-			learnMore := ""
-			if f.Rec.LearnMore != "" {
-				learnMore = fmt.Sprintf("[Docs](%s)", f.Rec.LearnMore)
+			if f.EntityType == "repo" {
+				repoFindings = append(repoFindings, f)
+			} else {
+				nonRepoFindings = append(nonRepoFindings, f)
 			}
-			sb.WriteString(fmt.Sprintf("| %s %s | %s | %s | %s | %s |\n",
-				severityEmoji[f.Rec.Severity], titleCase(f.Rec.Severity),
-				f.Entity, f.Rec.Issue, f.Rec.Recommendation, learnMore,
-			))
+		}
+
+		// Non-repo findings: full individual table.
+		if len(nonRepoFindings) > 0 {
+			sb.WriteString("| Severity | Entity | Finding | Action | Learn More |\n")
+			sb.WriteString("|----------|--------|---------|--------|------------|\n")
+
+			sort.Slice(nonRepoFindings, func(i, j int) bool {
+				return severityOrder[nonRepoFindings[i].Rec.Severity] < severityOrder[nonRepoFindings[j].Rec.Severity]
+			})
+
+			for _, f := range nonRepoFindings {
+				learnMore := ""
+				if f.Rec.LearnMore != "" {
+					learnMore = fmt.Sprintf("[Docs](%s)", f.Rec.LearnMore)
+				}
+				sb.WriteString(fmt.Sprintf("| %s %s | %s | %s | %s | %s |\n",
+					severityEmoji[f.Rec.Severity], titleCase(f.Rec.Severity),
+					f.Entity, f.Rec.Issue, f.Rec.Recommendation, learnMore,
+				))
+			}
+			sb.WriteString("\n")
+		}
+
+		// Repo findings: deduplicated and aggregated.
+		if len(repoFindings) > 0 {
+			if len(nonRepoFindings) > 0 {
+				sb.WriteString("**Repository-level findings (aggregated):**\n\n")
+			}
+			sb.WriteString("| Severity | Finding | Action | Repos Affected | Learn More |\n")
+			sb.WriteString("|----------|---------|--------|----------------|------------|\n")
+
+			type repoGroup struct {
+				Rec      recommendation
+				RepoSet  map[string]bool
+				KeyOrder int
+			}
+			groups := map[string]*repoGroup{}
+			var groupOrder []string
+
+			for _, f := range repoFindings {
+				key := f.Rec.groupKey()
+				if g, ok := groups[key]; ok {
+					g.RepoSet[f.Entity] = true
+				} else {
+					groups[key] = &repoGroup{
+						Rec:     f.Rec,
+						RepoSet: map[string]bool{f.Entity: true},
+					}
+					groupOrder = append(groupOrder, key)
+				}
+			}
+
+			// Sort groups by severity.
+			sort.Slice(groupOrder, func(i, j int) bool {
+				gi := groups[groupOrder[i]]
+				gj := groups[groupOrder[j]]
+				if severityOrder[gi.Rec.Severity] != severityOrder[gj.Rec.Severity] {
+					return severityOrder[gi.Rec.Severity] < severityOrder[gj.Rec.Severity]
+				}
+				return len(gi.RepoSet) > len(gj.RepoSet)
+			})
+
+			for _, key := range groupOrder {
+				g := groups[key]
+				learnMore := ""
+				if g.Rec.LearnMore != "" {
+					learnMore = fmt.Sprintf("[Docs](%s)", g.Rec.LearnMore)
+				}
+				sb.WriteString(fmt.Sprintf("| %s %s | %s | %s | %d | %s |\n",
+					severityEmoji[g.Rec.Severity], titleCase(g.Rec.Severity),
+					g.Rec.Issue, g.Rec.Recommendation, len(g.RepoSet), learnMore,
+				))
+			}
 		}
 
 		sb.WriteString("\n#### Why This Matters\n\n")
@@ -106,6 +176,36 @@ func generateFindingsByCategory(allFindings []entityFindings) string {
 	}
 
 	return sb.String()
+}
+
+// buildAffectedLabel produces a human-readable label like
+// "1 enterprise, 3 organizations, 4522 repositories".
+func buildAffectedLabel(entitySets map[string]map[string]bool) string {
+	typeLabels := []struct {
+		key      string
+		singular string
+		plural   string
+	}{
+		{"enterprise", "enterprise", "enterprises"},
+		{"ghes", "GHES instance", "GHES instances"},
+		{"org", "organization", "organizations"},
+		{"repo", "repository", "repositories"},
+	}
+
+	var parts []string
+	for _, tl := range typeLabels {
+		if s, ok := entitySets[tl.key]; ok && len(s) > 0 {
+			label := tl.singular
+			if len(s) > 1 {
+				label = tl.plural
+			}
+			parts = append(parts, fmt.Sprintf("%d %s", len(s), label))
+		}
+	}
+	if len(parts) == 0 {
+		return "—"
+	}
+	return strings.Join(parts, ", ")
 }
 
 // categoryRiskDescription returns a short business risk explanation for each category.

--- a/internal/renderers/markdown/markdown_document.go
+++ b/internal/renderers/markdown/markdown_document.go
@@ -33,6 +33,9 @@ func generateMarkdown(report *renderers.ScanReport) string {
 	sb.WriteString(fmt.Sprintf("**Generated:** %s\n", time.Now().Format("January 2, 2006")))
 	sb.WriteString(fmt.Sprintf("**Scan Coverage:** %d enterprises / %d GHES instances / %d organizations / %d repositories\n\n",
 		len(report.Enterprises), len(report.GHES), len(report.Organizations), len(report.Repositories)))
+	sb.WriteString("> 📊 This report provides an **executive-level summary**. Repository-level findings are\n")
+	sb.WriteString("> aggregated with affected-repository counts. For the complete per-repository breakdown,\n")
+	sb.WriteString("> refer to the accompanying **Excel report** (`.xlsx`) or the **JSON output** (`.json`).\n\n")
 	sb.WriteString("---\n\n")
 
 	// === Executive Summary ===
@@ -65,10 +68,6 @@ func generateMarkdown(report *renderers.ScanReport) string {
 
 	// === Manual Checks ===
 	sb.WriteString(generateManualChecks())
-	sb.WriteString("---\n\n")
-
-	// === Appendix ===
-	sb.WriteString(generateAppendix(report))
 
 	return sb.String()
 }

--- a/internal/renderers/markdown/markdown_manual_checks.go
+++ b/internal/renderers/markdown/markdown_manual_checks.go
@@ -4,11 +4,7 @@
 package markdown
 
 import (
-	"fmt"
-	"sort"
 	"strings"
-
-	"github.com/microsoft/ghqr/internal/renderers"
 )
 
 // generateManualChecks produces the manual checks table.
@@ -35,48 +31,6 @@ func generateManualChecks() string {
 	sb.WriteString("| Org webhooks | SSL verification enabled, shared secret set on all hooks | Org → Settings → Webhooks |\n")
 	sb.WriteString("| Org-level rulesets | At least one ruleset defined for repo governance | Org → Settings → Rules → Rulesets |\n")
 	sb.WriteString("\n")
-
-	return sb.String()
-}
-
-// generateAppendix produces the expandable appendix with all findings per entity.
-func generateAppendix(report *renderers.ScanReport) string {
-	var sb strings.Builder
-	sb.WriteString("## Appendix — Full Issue List\n\n")
-
-	allFindings := collectAllFindings(report)
-
-	for _, ef := range allFindings {
-		sb.WriteString(fmt.Sprintf("### %s\n\n", ef.EntityName))
-		sb.WriteString("<details>\n")
-		sb.WriteString("<summary>Expand all findings</summary>\n\n")
-		sb.WriteString("| Severity | Category | Finding | Action | Learn More |\n")
-		sb.WriteString("|----------|----------|---------|--------|------------|\n")
-
-		// Sort findings by severity.
-		sorted := make([]recommendation, len(ef.Findings))
-		copy(sorted, ef.Findings)
-		sort.Slice(sorted, func(i, j int) bool {
-			return severityOrder[sorted[i].Severity] < severityOrder[sorted[j].Severity]
-		})
-
-		for _, r := range sorted {
-			displayCat := categoryDisplayNames[r.Category]
-			if displayCat == "" {
-				displayCat = r.Category
-			}
-			learnMore := ""
-			if r.LearnMore != "" {
-				learnMore = fmt.Sprintf("[Link](%s)", r.LearnMore)
-			}
-			sb.WriteString(fmt.Sprintf("| %s %s | %s | %s | %s | %s |\n",
-				severityEmoji[r.Severity], titleCase(r.Severity),
-				displayCat, r.Issue, r.Recommendation, learnMore,
-			))
-		}
-
-		sb.WriteString("\n</details>\n\n")
-	}
 
 	return sb.String()
 }

--- a/internal/renderers/markdown/markdown_plan.go
+++ b/internal/renderers/markdown/markdown_plan.go
@@ -67,62 +67,85 @@ func generateRemediationPlan(allFindings []entityFindings) string {
 }
 
 // renderPlanTable renders the priority action table for a sprint.
+// Entities are not listed individually; only the count of affected entities
+// is shown, keeping the markdown report at executive-report size.
 func renderPlanTable(items []planItem) string {
 	if len(items) == 0 {
 		return "*No items in this phase.*\n"
 	}
 
 	var sb strings.Builder
-	sb.WriteString("| Priority | Entity | Action | Category | Effort | Owner |\n")
-	sb.WriteString("|----------|--------|--------|----------|--------|-------|\n")
+	sb.WriteString("| Priority | Action | Category | Affected Entities | Effort | Owner |\n")
+	sb.WriteString("|----------|--------|----------|-------------------|--------|-------|\n")
 
 	// Deduplicate: group same issue+category across entities.
 	type dedupeKey struct {
 		Issue    string
 		Category string
 	}
-	entitySets := map[dedupeKey]map[string]struct{}{}
-	recByKey := map[dedupeKey]recommendation{}
+	type dedupeEntry struct {
+		Rec        recommendation
+		EntitySets map[string]map[string]bool // entityType -> set of entity names
+	}
+	entries := map[dedupeKey]*dedupeEntry{}
 	keyOrder := make([]dedupeKey, 0, len(items))
 
 	for _, item := range items {
 		key := dedupeKey{Issue: item.Rec.Issue, Category: item.Rec.Category}
-		if _, ok := entitySets[key]; !ok {
-			entitySets[key] = map[string]struct{}{}
-			recByKey[key] = item.Rec
+		if e, ok := entries[key]; ok {
+			if e.EntitySets[entityTypeOf(item.Entity, items)] == nil {
+				e.EntitySets[entityTypeOf(item.Entity, items)] = map[string]bool{}
+			}
+			e.EntitySets[entityTypeOf(item.Entity, items)][item.Entity] = true
+		} else {
+			eType := entityTypeOf(item.Entity, items)
+			entries[key] = &dedupeEntry{
+				Rec: item.Rec,
+				EntitySets: map[string]map[string]bool{
+					eType: {item.Entity: true},
+				},
+			}
 			keyOrder = append(keyOrder, key)
 		}
-		entitySets[key][item.Entity] = struct{}{}
 	}
 
 	priority := 1
 	for _, key := range keyOrder {
-		entitySet := entitySets[key]
-		uniqueEntities := make([]string, 0, len(entitySet))
-		for e := range entitySet {
-			uniqueEntities = append(uniqueEntities, e)
-		}
-		sort.Strings(uniqueEntities)
-
-		rec := recByKey[key]
-		effort := estimateEffort(rec)
-		displayCat := categoryDisplayNames[rec.Category]
+		entry := entries[key]
+		effort := estimateEffort(entry.Rec)
+		displayCat := categoryDisplayNames[entry.Rec.Category]
 		if displayCat == "" {
-			displayCat = rec.Category
+			displayCat = entry.Rec.Category
 		}
 
-		sb.WriteString(fmt.Sprintf("| %d | %s | %s | %s | %s | %s |\n",
+		// Build "N entities" label.
+		totalEntities := 0
+		for _, set := range entry.EntitySets {
+			totalEntities += len(set)
+		}
+
+		sb.WriteString(fmt.Sprintf("| %d | %s | %s | %d | %s | %s |\n",
 			priority,
-			strings.Join(uniqueEntities, ", "),
-			rec.Recommendation,
+			entry.Rec.Recommendation,
 			displayCat,
+			totalEntities,
 			effort,
-			suggestOwner(rec.Category),
+			suggestOwner(entry.Rec.Category),
 		))
 		priority++
 	}
 
 	return sb.String()
+}
+
+// entityTypeOf returns the entity type for a given entity name within the plan items.
+func entityTypeOf(entity string, items []planItem) string {
+	// We don't have entity type in planItem directly, so infer from the name.
+	// Entities with "/" are repos (org/repo), others are orgs/enterprises.
+	if strings.Contains(entity, "/") {
+		return "repo"
+	}
+	return "other"
 }
 
 // estimateEffort provides S/M/L effort estimate based on the recommendation type.

--- a/internal/renderers/markdown/markdown_summary.go
+++ b/internal/renderers/markdown/markdown_summary.go
@@ -60,20 +60,47 @@ func generateExecutiveSummaryText(report *renderers.ScanReport, counts map[strin
 }
 
 // generatePostureScorecard builds the per-entity scorecard table.
+// Enterprise, GHES, and organization entities are shown individually.
+// Repository findings are aggregated into a single summary row to keep
+// the markdown report at executive-report size.
 func generatePostureScorecard(report *renderers.ScanReport) string {
 	var sb strings.Builder
 	sb.WriteString("| Entity | Type | Critical | High | Medium | Low | Info |\n")
 	sb.WriteString("|--------|------|----------|------|--------|-----|------|\n")
 
 	allFindings := collectAllFindings(report)
+
+	// Accumulate repo totals for aggregation.
+	repoSeverity := map[string]int{}
+	reposWithFindings := 0
+
 	for _, ef := range allFindings {
 		counts := map[string]int{}
 		for _, r := range ef.Findings {
 			counts[r.Severity]++
 		}
+
+		if ef.EntityType == "repo" {
+			for sev, c := range counts {
+				repoSeverity[sev] += c
+			}
+			reposWithFindings++
+			continue
+		}
+
 		sb.WriteString(fmt.Sprintf("| %s | %s | %d | %d | %d | %d | %d |\n",
 			ef.EntityName, ef.EntityType,
 			counts["critical"], counts["high"], counts["medium"], counts["low"], counts["info"],
+		))
+	}
+
+	// Single aggregated row for all repositories.
+	if len(report.Repositories) > 0 {
+		label := fmt.Sprintf("Repositories — %d affected of %d scanned", reposWithFindings, len(report.Repositories))
+		sb.WriteString(fmt.Sprintf("| %s | repo | %d | %d | %d | %d | %d |\n",
+			label,
+			repoSeverity["critical"], repoSeverity["high"], repoSeverity["medium"],
+			repoSeverity["low"], repoSeverity["info"],
 		))
 	}
 

--- a/internal/renderers/markdown/markdown_types.go
+++ b/internal/renderers/markdown/markdown_types.go
@@ -5,11 +5,22 @@ package markdown
 
 // recommendation represents a single finding from the scan.
 type recommendation struct {
+	RuleID         string `json:"rule_id,omitempty"`
 	Severity       string `json:"severity"`
 	Category       string `json:"category"`
 	Issue          string `json:"issue"`
 	Recommendation string `json:"recommendation"`
 	LearnMore      string `json:"learn_more,omitempty"`
+}
+
+// groupKey returns a stable deduplication key for this recommendation.
+// It prefers RuleID when available; otherwise falls back to the
+// (Severity, Category, Recommendation) triple.
+func (r recommendation) groupKey() string {
+	if r.RuleID != "" {
+		return r.RuleID + "|" + r.Severity + "|" + r.Category
+	}
+	return r.Severity + "|" + r.Category + "|" + r.Recommendation
 }
 
 // entityFindings groups findings by entity for report generation.


### PR DESCRIPTION
## Summary

Reduces the markdown report from **~45MB to ~125KB** (99.7% reduction) for large enterprise scans by making it an executive-level summary.

### Changes
- **Scorecard:** repos aggregated into a single summary row
- **Findings by category:** repo findings deduplicated with affected-repo counts
- **Remediation plan:** entity counts instead of listing all entity names
- **Appendix removed:** redundant with Excel reference
- **Header note:** references Excel/JSON for per-repo drill-down
- **RuleID field:** added for stable deduplication

### What stays the same
- Excel and JSON outputs remain unchanged (full per-repo detail)
- Enterprise/org/GHES findings shown individually in all sections

### Testing
- All existing tests pass (`go test ./...`)
- Validated with real 4522-repo scan: 45MB → 125KB, 156K lines → 1010 lines

Closes #129