### PR TITLE
Fix Excel report inconsistencies: rulesets, replay entity sheets, and enterprise Budgets/GHAS

### DIFF
--- a/internal/renderers/excel/branch_protection.go
+++ b/internal/renderers/excel/branch_protection.go
@@ -28,9 +28,7 @@ func renderBranchProtection(f *excelize.File, results map[string]interface{}, st
 	}
 
 	data := buildBranchProtectionTable(results)
-	rows := make([][]string, 0, len(data)+1)
-	rows = append(rows, headers)
-	rows = append(rows, data...)
+	rows := append([][]string{headers}, data...)
 	streamSheet(f, sheet, rows, styles)
 }
 

--- a/internal/renderers/excel/branch_protection.go
+++ b/internal/renderers/excel/branch_protection.go
@@ -21,7 +21,7 @@ func renderBranchProtection(f *excelize.File, results map[string]interface{}, st
 	}
 
 	headers := []string{
-		"Repository", "Branch", "Protected",
+		"Repository", "Branch", "Protected", "Protection Source",
 		"Required Approvals", "Dismiss Stale Reviews", "Require CODEOWNERS",
 		"Require Status Checks", "Strict Status Checks",
 		"Allow Force Pushes", "Allow Deletions", "Required Signatures",
@@ -47,42 +47,12 @@ func buildBranchProtectionTable(results map[string]interface{}) [][]string {
 			continue
 		}
 		name := strings.TrimPrefix(key, "repository:")
-		repoData, ok := val.(*scanners.RepositoryData)
-		if !ok {
+		repoData := asType[scanners.RepositoryData](val)
+		if repoData == nil {
 			continue
 		}
 
-		bp := repoData.BranchProtection
-		if bp == nil {
-			bp = &scanners.BranchProtectionDetail{}
-		}
-
-		protected := boolStr(bp.Protected)
-		branch := bp.Branch
-		requiredApprovals := ""
-		dismissStale := ""
-		requireCodeowners := ""
-		requireStatusChecks := boolStr(bp.RequiredStatusChecks != nil)
-		strictStatusChecks := ""
-		allowForcePushes := boolStr(bp.AllowForcePushes)
-		allowDeletions := boolStr(bp.AllowDeletions)
-		requiredSignatures := boolStr(bp.RequiredSignatures)
-
-		if r := bp.RequiredPullRequestReviews; r != nil {
-			requiredApprovals = strconv.Itoa(r.RequiredApprovingReviewCount)
-			dismissStale = boolStr(r.DismissStaleReviews)
-			requireCodeowners = boolStr(r.RequireCodeOwnerReviews)
-		}
-		if sc := bp.RequiredStatusChecks; sc != nil {
-			strictStatusChecks = boolStr(sc.Strict)
-		}
-
-		rows = append(rows, row{name: name, cols: []string{
-			name, branch, protected,
-			requiredApprovals, dismissStale, requireCodeowners,
-			requireStatusChecks, strictStatusChecks,
-			allowForcePushes, allowDeletions, requiredSignatures,
-		}})
+		rows = append(rows, row{name: name, cols: branchProtectionRow(name, repoData)})
 	}
 
 	sort.Slice(rows, func(i, j int) bool { return rows[i].name < rows[j].name })
@@ -92,4 +62,85 @@ func buildBranchProtectionTable(results map[string]interface{}) [][]string {
 		result = append(result, r.cols)
 	}
 	return result
+}
+
+// effectiveBranchProtection holds the branch-protection fields resolved from
+// whichever mechanism actually protects the default branch: a legacy branch
+// protection rule or a repository ruleset.
+type effectiveBranchProtection struct {
+	source               string
+	branch               string
+	protected            bool
+	requiredReviews      *scanners.RequiredPRReviews
+	requiredStatusChecks *scanners.RequiredStatusChecks
+	allowForcePushes     bool
+	allowDeletions       bool
+	requiredSignatures   bool
+}
+
+// resolveBranchProtection determines the effective branch protection for a
+// repository. Legacy branch protection takes precedence; when it is absent the
+// repository's ruleset-based protection is used. This mirrors the precedence
+// applied by the evaluation stage so the Excel report matches the findings.
+func resolveBranchProtection(repo *scanners.RepositoryData) effectiveBranchProtection {
+	bp := repo.BranchProtection
+	rs := repo.RulesetProtection
+
+	switch {
+	case bp != nil && bp.Protected:
+		return effectiveBranchProtection{
+			source:               "Branch Protection",
+			branch:               bp.Branch,
+			protected:            true,
+			requiredReviews:      bp.RequiredPullRequestReviews,
+			requiredStatusChecks: bp.RequiredStatusChecks,
+			allowForcePushes:     bp.AllowForcePushes,
+			allowDeletions:       bp.AllowDeletions,
+			requiredSignatures:   bp.RequiredSignatures,
+		}
+	case rs != nil && rs.Protected:
+		return effectiveBranchProtection{
+			source:               "Ruleset",
+			branch:               rs.Branch,
+			protected:            true,
+			requiredReviews:      rs.RequiredPullRequestReviews,
+			requiredStatusChecks: rs.RequiredStatusChecks,
+			allowForcePushes:     rs.AllowForcePushes,
+			allowDeletions:       rs.AllowDeletions,
+			requiredSignatures:   rs.RequiredSignatures,
+		}
+	default:
+		branch := ""
+		if bp != nil {
+			branch = bp.Branch
+		}
+		return effectiveBranchProtection{source: "None", branch: branch}
+	}
+}
+
+// branchProtectionRow builds a single BranchProtection sheet row for a
+// repository, using its effective protection (legacy rule or ruleset).
+func branchProtectionRow(name string, repo *scanners.RepositoryData) []string {
+	e := resolveBranchProtection(repo)
+
+	requiredApprovals := ""
+	dismissStale := ""
+	requireCodeowners := ""
+	if r := e.requiredReviews; r != nil {
+		requiredApprovals = strconv.Itoa(r.RequiredApprovingReviewCount)
+		dismissStale = boolStr(r.DismissStaleReviews)
+		requireCodeowners = boolStr(r.RequireCodeOwnerReviews)
+	}
+
+	strictStatusChecks := ""
+	if sc := e.requiredStatusChecks; sc != nil {
+		strictStatusChecks = boolStr(sc.Strict)
+	}
+
+	return []string{
+		name, e.branch, boolStr(e.protected), e.source,
+		requiredApprovals, dismissStale, requireCodeowners,
+		boolStr(e.requiredStatusChecks != nil), strictStatusChecks,
+		boolStr(e.allowForcePushes), boolStr(e.allowDeletions), boolStr(e.requiredSignatures),
+	}
 }

--- a/internal/renderers/excel/branch_protection_test.go
+++ b/internal/renderers/excel/branch_protection_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package excel
+
+import (
+	"testing"
+
+	"github.com/microsoft/ghqr/internal/scanners"
+)
+
+// Column indexes within a BranchProtection sheet data row.
+const (
+	colRepository = iota
+	colBranch
+	colProtected
+	colSource
+	colRequiredApprovals
+	colDismissStale
+	colRequireCodeowners
+	colRequireStatusChecks
+	colStrictStatusChecks
+	colAllowForcePushes
+	colAllowDeletions
+	colRequiredSignatures
+	colCount
+)
+
+func TestBuildBranchProtectionTable(t *testing.T) {
+	tests := []struct {
+		name string
+		repo *scanners.RepositoryData
+		want map[int]string
+	}{
+		{
+			name: "legacy branch protection takes precedence",
+			repo: &scanners.RepositoryData{
+				BranchProtection: &scanners.BranchProtectionDetail{
+					Protected:          true,
+					Branch:             "main",
+					AllowForcePushes:   false,
+					AllowDeletions:     false,
+					RequiredSignatures: true,
+					RequiredPullRequestReviews: &scanners.RequiredPRReviews{
+						RequiredApprovingReviewCount: 2,
+						DismissStaleReviews:          true,
+						RequireCodeOwnerReviews:      true,
+					},
+					RequiredStatusChecks: &scanners.RequiredStatusChecks{Strict: true},
+				},
+				// Ruleset present too, but legacy must win.
+				RulesetProtection: &scanners.RulesetProtectionDetail{Protected: true, RulesetCount: 1},
+			},
+			want: map[int]string{
+				colBranch:              "main",
+				colProtected:           "Yes",
+				colSource:              "Branch Protection",
+				colRequiredApprovals:   "2",
+				colDismissStale:        "Yes",
+				colRequireCodeowners:   "Yes",
+				colRequireStatusChecks: "Yes",
+				colStrictStatusChecks:  "Yes",
+				colAllowForcePushes:    "No",
+				colAllowDeletions:      "No",
+				colRequiredSignatures:  "Yes",
+			},
+		},
+		{
+			name: "ruleset-only protection is reflected",
+			repo: &scanners.RepositoryData{
+				BranchProtection: &scanners.BranchProtectionDetail{Protected: false},
+				RulesetProtection: &scanners.RulesetProtectionDetail{
+					Protected:        true,
+					Branch:           "main",
+					AllowForcePushes: false,
+					AllowDeletions:   false,
+					RulesetCount:     1,
+					RequiredPullRequestReviews: &scanners.RequiredPRReviews{
+						RequiredApprovingReviewCount: 1,
+					},
+				},
+			},
+			want: map[int]string{
+				colBranch:              "main",
+				colProtected:           "Yes",
+				colSource:              "Ruleset",
+				colRequiredApprovals:   "1",
+				colDismissStale:        "No",
+				colRequireCodeowners:   "No",
+				colRequireStatusChecks: "No",
+				colStrictStatusChecks:  "",
+				colAllowForcePushes:    "No",
+				colAllowDeletions:      "No",
+				colRequiredSignatures:  "No",
+			},
+		},
+		{
+			name: "unprotected repository",
+			repo: &scanners.RepositoryData{
+				BranchProtection: &scanners.BranchProtectionDetail{Protected: false},
+			},
+			want: map[int]string{
+				colBranch:            "",
+				colProtected:         "No",
+				colSource:            "None",
+				colRequiredApprovals: "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := map[string]interface{}{
+				"repository:owner/repo": tt.repo,
+			}
+
+			table := buildBranchProtectionTable(results)
+			if len(table) != 1 {
+				t.Fatalf("expected 1 row, got %d", len(table))
+			}
+			row := table[0]
+			if len(row) != colCount {
+				t.Fatalf("expected %d columns, got %d", colCount, len(row))
+			}
+			if row[colRepository] != "owner/repo" {
+				t.Errorf("repository = %q, want %q", row[colRepository], "owner/repo")
+			}
+			for idx, want := range tt.want {
+				if row[idx] != want {
+					t.Errorf("column %d = %q, want %q", idx, row[idx], want)
+				}
+			}
+		})
+	}
+}

--- a/internal/renderers/excel/budgets.go
+++ b/internal/renderers/excel/budgets.go
@@ -28,9 +28,7 @@ func renderBudgets(f *excelize.File, results map[string]interface{}, styles *Sty
 	}
 
 	data := buildBudgetsTable(results)
-	rows := make([][]string, 0, len(data)+1)
-	rows = append(rows, headers)
-	rows = append(rows, data...)
+	rows := append([][]string{headers}, data...)
 	streamSheet(f, sheet, rows, styles)
 }
 

--- a/internal/renderers/excel/budgets.go
+++ b/internal/renderers/excel/budgets.go
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package excel
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/microsoft/ghqr/internal/scanners"
+	"github.com/rs/zerolog/log"
+	"github.com/xuri/excelize/v2"
+)
+
+// renderBudgets writes the Budgets sheet, listing every enterprise billing
+// budget with its scope, amount, alerting, and usage-prevention configuration.
+func renderBudgets(f *excelize.File, results map[string]interface{}, styles *StyleCache) {
+	const sheet = "Budgets"
+	if _, err := f.NewSheet(sheet); err != nil {
+		log.Error().Err(err).Msg("Failed to create Budgets sheet")
+		return
+	}
+
+	headers := []string{
+		"Enterprise", "Budget Entity", "Scope", "Type", "Product/SKUs",
+		"Amount ($)", "Prevent Overage", "Alerting", "Alert Recipients", "Budget ID",
+	}
+
+	data := buildBudgetsTable(results)
+	rows := make([][]string, 0, len(data)+1)
+	rows = append(rows, headers)
+	rows = append(rows, data...)
+	streamSheet(f, sheet, rows, styles)
+}
+
+func buildBudgetsTable(results map[string]interface{}) [][]string {
+	type row struct {
+		enterprise string
+		entity     string
+		cols       []string
+	}
+
+	var rows []row
+
+	for key, val := range results {
+		if !strings.HasPrefix(key, "enterprise:") {
+			continue
+		}
+		name := strings.TrimPrefix(key, "enterprise:")
+		entData := asType[scanners.EnterpriseData](val)
+		if entData == nil {
+			continue
+		}
+
+		budgets := entData.Budgets
+
+		// Distinguish "no access" from "zero budgets configured" so the sheet
+		// never silently hides an enterprise.
+		if budgets == nil || !budgets.Available {
+			rows = append(rows, row{enterprise: name, cols: []string{
+				name, "—", "N/A", "Budget data not available (no access)", "", "", "", "", "", "",
+			}})
+			continue
+		}
+		if len(budgets.Budgets) == 0 {
+			rows = append(rows, row{enterprise: name, cols: []string{
+				name, "—", "—", "No budgets configured", "", "", "", "", "", "",
+			}})
+			continue
+		}
+
+		for _, b := range budgets.Budgets {
+			if b == nil {
+				continue
+			}
+			entity := b.BudgetEntityName
+			if entity == "" {
+				entity = "—"
+			}
+			skus := ""
+			if len(b.BudgetProductSkus) > 0 {
+				skus = strings.Join(b.BudgetProductSkus, ", ")
+			}
+			alerting := "No"
+			recipients := ""
+			if b.BudgetAlerting != nil {
+				alerting = boolStr(b.BudgetAlerting.WillAlert)
+				recipients = strings.Join(b.BudgetAlerting.AlertRecipients, ", ")
+			}
+
+			rows = append(rows, row{enterprise: name, entity: b.BudgetEntityName, cols: []string{
+				name, entity, b.BudgetScope, b.BudgetType, skus,
+				strconv.Itoa(b.BudgetAmount), boolStr(b.PreventFurtherUsage),
+				alerting, recipients, b.ID,
+			}})
+		}
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].enterprise != rows[j].enterprise {
+			return rows[i].enterprise < rows[j].enterprise
+		}
+		return rows[i].entity < rows[j].entity
+	})
+
+	result := make([][]string, 0, len(rows))
+	for _, r := range rows {
+		result = append(result, r.cols)
+	}
+	return result
+}

--- a/internal/renderers/excel/budgets_ghas_test.go
+++ b/internal/renderers/excel/budgets_ghas_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package excel
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/microsoft/ghqr/internal/scanners"
+)
+
+func TestBuildBudgetsTable(t *testing.T) {
+	ent := &scanners.EnterpriseData{
+		Budgets: &scanners.EnterpriseBudgets{
+			Available:  true,
+			TotalCount: 2,
+			Budgets: []*scanners.BudgetEntry{
+				{
+					ID:                  "b-1",
+					BudgetType:          "BundlePricing",
+					BudgetScope:         "enterprise",
+					BudgetEntityName:    "acme",
+					BudgetAmount:        1000,
+					PreventFurtherUsage: true,
+					BudgetProductSkus:   []string{"actions", "copilot"},
+					BudgetAlerting: &scanners.BudgetAlertConfig{
+						WillAlert:       true,
+						AlertRecipients: []string{"U1", "U2"},
+					},
+				},
+				{
+					ID:           "b-2",
+					BudgetType:   "BundlePricing",
+					BudgetScope:  "organization",
+					BudgetAmount: 50,
+					// No alerting configured.
+				},
+			},
+		},
+	}
+
+	t.Run("live struct and replay map produce identical rows", func(t *testing.T) {
+		replay := toMap(t, ent)
+		for label, val := range map[string]interface{}{"struct": ent, "map": replay} {
+			results := map[string]interface{}{"enterprise:acme": val}
+			table := buildBudgetsTable(results)
+			if len(table) != 2 {
+				t.Fatalf("[%s] expected 2 rows, got %d", label, len(table))
+			}
+			// Rows are sorted by entity name; the budget with an empty entity
+			// ("—") sorts before "acme".
+			r0 := table[0]
+			want0 := []string{"acme", "—", "organization", "BundlePricing", "", "50", "No", "No", "", "b-2"}
+			assertRow(t, label+"/row0", r0, want0)
+			r1 := table[1]
+			want1 := []string{"acme", "acme", "enterprise", "BundlePricing", "actions, copilot", "1000", "Yes", "Yes", "U1, U2", "b-1"}
+			assertRow(t, label+"/row1", r1, want1)
+		}
+	})
+
+	t.Run("no access", func(t *testing.T) {
+		results := map[string]interface{}{
+			"enterprise:acme": &scanners.EnterpriseData{
+				Budgets: &scanners.EnterpriseBudgets{Available: false},
+			},
+		}
+		table := buildBudgetsTable(results)
+		if len(table) != 1 {
+			t.Fatalf("expected 1 row, got %d", len(table))
+		}
+		if table[0][3] != "Budget data not available (no access)" {
+			t.Errorf("type column = %q", table[0][3])
+		}
+	})
+
+	t.Run("available but zero budgets", func(t *testing.T) {
+		results := map[string]interface{}{
+			"enterprise:acme": &scanners.EnterpriseData{
+				Budgets: &scanners.EnterpriseBudgets{Available: true},
+			},
+		}
+		table := buildBudgetsTable(results)
+		if len(table) != 1 {
+			t.Fatalf("expected 1 row, got %d", len(table))
+		}
+		if table[0][3] != "No budgets configured" {
+			t.Errorf("type column = %q", table[0][3])
+		}
+	})
+}
+
+func TestBuildGHASTable(t *testing.T) {
+	ent := &scanners.EnterpriseData{
+		GHASSettings: &scanners.EnterpriseGHASSettings{
+			AdvancedSecurity:                  "enabled",
+			SecretScanning:                    "enabled",
+			SecretScanningPushProtection:      "disabled",
+			DependabotAlerts:                  "enabled",
+			DependabotSecurityUpdates:         "not_set",
+			DependencyGraph:                   "enabled",
+			SecretScanningNonProviderPatterns: "", // -> not_set
+		},
+	}
+
+	t.Run("live struct and replay map produce identical rows", func(t *testing.T) {
+		replay := toMap(t, ent)
+		want := []string{"acme", "enabled", "enabled", "disabled", "enabled", "not_set", "enabled", "not_set"}
+		for label, val := range map[string]interface{}{"struct": ent, "map": replay} {
+			results := map[string]interface{}{"enterprise:acme": val}
+			table := buildGHASTable(results)
+			if len(table) != 1 {
+				t.Fatalf("[%s] expected 1 row, got %d", label, len(table))
+			}
+			assertRow(t, label, table[0], want)
+		}
+	})
+
+	t.Run("settings not available", func(t *testing.T) {
+		results := map[string]interface{}{
+			"enterprise:acme": &scanners.EnterpriseData{},
+		}
+		table := buildGHASTable(results)
+		if len(table) != 1 {
+			t.Fatalf("expected 1 row, got %d", len(table))
+		}
+		for i := 1; i < len(table[0]); i++ {
+			if table[0][i] != "Not available" {
+				t.Errorf("column %d = %q, want %q", i, table[0][i], "Not available")
+			}
+		}
+	})
+}
+
+// toMap round-trips a value through JSON to emulate the map[string]interface{}
+// shape stored when replaying a scan from a JSON file (--from-json).
+func toMap(t *testing.T, v interface{}) map[string]interface{} {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return m
+}
+
+func assertRow(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("[%s] row len = %d, want %d (%v)", label, len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%s] col %d = %q, want %q", label, i, got[i], want[i])
+		}
+	}
+}

--- a/internal/renderers/excel/convert.go
+++ b/internal/renderers/excel/convert.go
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package excel
+
+import "encoding/json"
+
+// asType converts a scan-result value into the desired concrete type.
+//
+// Live scans store typed pointers (e.g. *scanners.RepositoryData) directly in
+// the results map, whereas replays loaded from a previous scan JSON via
+// --from-json store map[string]interface{}. This helper handles both shapes by
+// returning the value directly when it is already the right pointer type, and
+// otherwise falling back to a JSON round-trip. It returns nil when the value is
+// nil or cannot be converted.
+func asType[T any](v interface{}) *T {
+	if v == nil {
+		return nil
+	}
+	if t, ok := v.(*T); ok {
+		return t
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	var out T
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil
+	}
+	return &out
+}

--- a/internal/renderers/excel/excel.go
+++ b/internal/renderers/excel/excel.go
@@ -75,6 +75,8 @@ func CreateExcelReport(results map[string]interface{}, outputName string) {
 	renderOrganizations(f, results, styles)
 	renderRepositories(f, results, styles)
 	renderBranchProtection(f, results, styles)
+	renderBudgets(f, results, styles)
+	renderGHAS(f, results, styles)
 	renderIssues(f, results, styles)
 
 	// Remove the default empty "Sheet1" that excelize creates.

--- a/internal/renderers/excel/ghas.go
+++ b/internal/renderers/excel/ghas.go
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package excel
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/microsoft/ghqr/internal/scanners"
+	"github.com/rs/zerolog/log"
+	"github.com/xuri/excelize/v2"
+)
+
+// renderGHAS writes the GHAS sheet, showing the enterprise-wide GitHub Advanced
+// Security policy defaults that cascade to all organizations.
+func renderGHAS(f *excelize.File, results map[string]interface{}, styles *StyleCache) {
+	const sheet = "GHAS"
+	if _, err := f.NewSheet(sheet); err != nil {
+		log.Error().Err(err).Msg("Failed to create GHAS sheet")
+		return
+	}
+
+	headers := []string{
+		"Enterprise", "Advanced Security", "Secret Scanning",
+		"Secret Scanning Push Protection", "Dependabot Alerts",
+		"Dependabot Security Updates", "Dependency Graph",
+		"Secret Scanning Non-Provider Patterns",
+	}
+
+	data := buildGHASTable(results)
+	rows := make([][]string, 0, len(data)+1)
+	rows = append(rows, headers)
+	rows = append(rows, data...)
+	streamSheet(f, sheet, rows, styles)
+}
+
+// ghasVal normalizes a GHAS policy value for display. Empty values are shown as
+// "not_set" to match GitHub's own terminology.
+func ghasVal(v string) string {
+	if v == "" {
+		return "not_set"
+	}
+	return v
+}
+
+func buildGHASTable(results map[string]interface{}) [][]string {
+	type row struct {
+		name string
+		cols []string
+	}
+
+	var rows []row
+
+	for key, val := range results {
+		if !strings.HasPrefix(key, "enterprise:") {
+			continue
+		}
+		name := strings.TrimPrefix(key, "enterprise:")
+		entData := asType[scanners.EnterpriseData](val)
+		if entData == nil {
+			continue
+		}
+
+		s := entData.GHASSettings
+		if s == nil {
+			// Endpoint not accessible (requires enterprise admin token); still
+			// list the enterprise so its absence is explicit.
+			na := "Not available"
+			rows = append(rows, row{name: name, cols: []string{
+				name, na, na, na, na, na, na, na,
+			}})
+			continue
+		}
+
+		rows = append(rows, row{name: name, cols: []string{
+			name,
+			ghasVal(s.AdvancedSecurity),
+			ghasVal(s.SecretScanning),
+			ghasVal(s.SecretScanningPushProtection),
+			ghasVal(s.DependabotAlerts),
+			ghasVal(s.DependabotSecurityUpdates),
+			ghasVal(s.DependencyGraph),
+			ghasVal(s.SecretScanningNonProviderPatterns),
+		}})
+	}
+
+	sort.Slice(rows, func(i, j int) bool { return rows[i].name < rows[j].name })
+
+	result := make([][]string, 0, len(rows))
+	for _, r := range rows {
+		result = append(result, r.cols)
+	}
+	return result
+}

--- a/internal/renderers/excel/ghas.go
+++ b/internal/renderers/excel/ghas.go
@@ -29,9 +29,7 @@ func renderGHAS(f *excelize.File, results map[string]interface{}, styles *StyleC
 	}
 
 	data := buildGHASTable(results)
-	rows := make([][]string, 0, len(data)+1)
-	rows = append(rows, headers)
-	rows = append(rows, data...)
+	rows := append([][]string{headers}, data...)
 	streamSheet(f, sheet, rows, styles)
 }
 

--- a/internal/renderers/excel/issues.go
+++ b/internal/renderers/excel/issues.go
@@ -22,9 +22,7 @@ func renderIssues(f *excelize.File, results map[string]interface{}, styles *Styl
 	headers := []string{"Type", "Name", "Severity", "Category", "Issue", "Recommendation", "Learn More"}
 
 	data := buildIssuesTable(results)
-	rows := make([][]string, 0, len(data)+1)
-	rows = append(rows, headers)
-	rows = append(rows, data...)
+	rows := append([][]string{headers}, data...)
 	streamSheet(f, sheet, rows, styles)
 }
 

--- a/internal/renderers/excel/issues.go
+++ b/internal/renderers/excel/issues.go
@@ -98,6 +98,12 @@ func buildIssuesTable(results map[string]interface{}) [][]string {
 		case strings.HasPrefix(key, "evaluation:enterprise_security_alerts:"):
 			entityType = "enterprise_security_alerts"
 			name = strings.TrimPrefix(key, "evaluation:enterprise_security_alerts:")
+		case strings.HasPrefix(key, "evaluation:enterprise_ghas:"):
+			entityType = "enterprise_ghas"
+			name = strings.TrimPrefix(key, "evaluation:enterprise_ghas:")
+		case strings.HasPrefix(key, "evaluation:enterprise_budgets:"):
+			entityType = "enterprise_budgets"
+			name = strings.TrimPrefix(key, "evaluation:enterprise_budgets:")
 		case strings.HasPrefix(key, "evaluation:security_managers:"):
 			entityType = "security_managers"
 			name = strings.TrimPrefix(key, "evaluation:security_managers:")

--- a/internal/renderers/excel/issues_test.go
+++ b/internal/renderers/excel/issues_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package excel
+
+import (
+	"testing"
+
+	"github.com/microsoft/ghqr/internal/scanners/bestpractices"
+)
+
+func TestBuildIssuesTable_EnterpriseBudgetsAndGHAS(t *testing.T) {
+	results := map[string]interface{}{
+		"evaluation:enterprise_budgets:acme": &bestpractices.EvaluationResult{
+			Recommendations: []bestpractices.Issue{
+				{
+					Severity:       bestpractices.SeverityInfo,
+					Category:       bestpractices.CategoryBudget,
+					Issue:          "19 budget(s) configured",
+					Recommendation: "Keep monitoring",
+				},
+			},
+		},
+		"evaluation:enterprise_ghas:acme": &bestpractices.EvaluationResult{
+			Recommendations: []bestpractices.Issue{
+				{
+					Severity:       bestpractices.SeverityHigh,
+					Category:       bestpractices.CategorySecurity,
+					Issue:          "Advanced Security not enabled by default",
+					Recommendation: "Enable GHAS defaults",
+				},
+			},
+		},
+	}
+
+	rows := buildIssuesTable(results)
+
+	found := map[string]string{} // entityType -> issue text
+	for _, r := range rows {
+		// columns: Type, Name, Severity, Category, Issue, Recommendation, Learn More
+		found[r[0]] = r[4]
+	}
+
+	if got, ok := found["enterprise_budgets"]; !ok || got != "19 budget(s) configured" {
+		t.Errorf("enterprise_budgets finding missing/incorrect: %q (present=%v)", got, ok)
+	}
+	if got, ok := found["enterprise_ghas"]; !ok || got != "Advanced Security not enabled by default" {
+		t.Errorf("enterprise_ghas finding missing/incorrect: %q (present=%v)", got, ok)
+	}
+}

--- a/internal/renderers/excel/organizations.go
+++ b/internal/renderers/excel/organizations.go
@@ -30,9 +30,7 @@ func renderOrganizations(f *excelize.File, results map[string]interface{}, style
 	}
 
 	data := buildOrganizationsTable(results)
-	rows := make([][]string, 0, len(data)+1)
-	rows = append(rows, headers)
-	rows = append(rows, data...)
+	rows := append([][]string{headers}, data...)
 	streamSheet(f, sheet, rows, styles)
 }
 

--- a/internal/renderers/excel/organizations.go
+++ b/internal/renderers/excel/organizations.go
@@ -49,8 +49,8 @@ func buildOrganizationsTable(results map[string]interface{}) [][]string {
 			continue
 		}
 		name := strings.TrimPrefix(key, "organization:")
-		orgData, ok := val.(*scanners.OrganizationData)
-		if !ok {
+		orgData := asType[scanners.OrganizationData](val)
+		if orgData == nil {
 			continue
 		}
 

--- a/internal/renderers/excel/repositories.go
+++ b/internal/renderers/excel/repositories.go
@@ -48,8 +48,8 @@ func buildRepositoriesTable(results map[string]interface{}) [][]string {
 			continue
 		}
 		name := strings.TrimPrefix(key, "repository:")
-		repoData, ok := val.(*scanners.RepositoryData)
-		if !ok {
+		repoData := asType[scanners.RepositoryData](val)
+		if repoData == nil {
 			continue
 		}
 

--- a/internal/renderers/excel/repositories.go
+++ b/internal/renderers/excel/repositories.go
@@ -29,9 +29,7 @@ func renderRepositories(f *excelize.File, results map[string]interface{}, styles
 	}
 
 	data := buildRepositoriesTable(results)
-	rows := make([][]string, 0, len(data)+1)
-	rows = append(rows, headers)
-	rows = append(rows, data...)
+	rows := append([][]string{headers}, data...)
 	streamSheet(f, sheet, rows, styles)
 }
 


### PR DESCRIPTION
## Summary

Fixes several inconsistencies where the Excel report did not reflect data that is present in the JSON output (and, for branch protection, in the Markdown report). The Markdown report intentionally stays executive (totals only); the 1-to-1 detail lives in the Excel sheets.

## Changes

### 1. BranchProtection sheet reflects repository rulesets (fixes #152)
The `BranchProtection` sheet only read legacy branch-protection rules and ignored repository **rulesets**, so ruleset-protected repos appeared unprotected (all `No`/blank). It now resolves the effective protection with the same precedence as the evaluation stage (legacy first, then ruleset) and adds a **Protection Source** column (`Branch Protection` / `Ruleset` / `None`).

### 2. Entity sheets populate in replay mode (`--from-json`)
`Organizations`, `Repositories`, and `BranchProtection` used a direct type assertion to the concrete scanner types, which fails when entities are loaded from JSON as `map[string]interface{}`. A new `asType[T]` helper (mirrors the evaluation stage's `toType`) accepts both shapes, so these sheets are no longer empty on replay.

### 3. New Budgets and GHAS sheets
- **Budgets** — one row per enterprise budget (entity, scope, type, product/SKUs, amount, prevent-overage, alerting, alert recipients, id), distinguishing "no access" from "no budgets configured".
- **GHAS** — one row per enterprise with the 7 enterprise-wide GitHub Advanced Security policy defaults; renders "Not available" when the endpoint is inaccessible.

### 4. Findings sheet no longer drops enterprise findings
`buildIssuesTable` had no case for `enterprise_budgets` / `enterprise_ghas`, so their recommendations were silently dropped via `default: continue`. Both are now mapped.

## Files
- `internal/renderers/excel/convert.go` (new)
- `internal/renderers/excel/budgets.go` (new)
- `internal/renderers/excel/ghas.go` (new)
- `internal/renderers/excel/branch_protection.go`
- `internal/renderers/excel/organizations.go`
- `internal/renderers/excel/repositories.go`
- `internal/renderers/excel/issues.go`
- `internal/renderers/excel/excel.go`
- Tests: `branch_protection_test.go`, `budgets_ghas_test.go`, `issues_test.go`

## Testing
- `go vet ./...` clean; full `go test ./...` passes.
- Verified end-to-end by regenerating the Excel from an existing scan JSON (`--from-json`): ruleset-protected repos show `Protected = Yes` / `Protection Source = Ruleset`, entity sheets populate, the Budgets sheet lists every budget, the GHAS sheet lists the enterprise, and the enterprise budget finding now appears in the Findings sheet.

Closes #152
Closes #153
